### PR TITLE
Added decklist sort by Faction then Set

### DIFF
--- a/src/AppBundle/Resources/public/js/deckview.js
+++ b/src/AppBundle/Resources/public/js/deckview.js
@@ -39,6 +39,7 @@ function do_action_deck(event) {
 		case 'btn-sort-number': DisplaySort = 'number'; DisplaySortSecondary = null; switch_to_web_view(); break;
 		case 'btn-sort-faction': DisplaySort = 'faction'; DisplaySortSecondary = null; switch_to_web_view(); break;
 		case 'btn-sort-faction-type': DisplaySort = 'faction'; DisplaySortSecondary = 'type'; switch_to_web_view(); break;
+		case 'btn-sort-faction-number': DisplaySort = 'faction'; DisplaySortSecondary = 'number'; switch_to_web_view(); break;
 		case 'btn-sort-title': DisplaySort = 'title'; DisplaySortSecondary = null; switch_to_web_view(); break;
 		case 'btn-display-plain': export_plaintext(); break;
 		case 'btn-display-bbcode': export_bbcode(); break;

--- a/src/AppBundle/Resources/public/js/nrdb.js
+++ b/src/AppBundle/Resources/public/js/nrdb.js
@@ -281,6 +281,9 @@ function update_deck(options) {
 		case 'faction':
 			order += ',faction_code';
 			break;
+		case 'number':
+			order = 'code';
+			break;
 	}
 	order += ',title';
 	NRDB.data.cards({indeck:{'gt':0},type_code:{'!is':'identity'}}).order(order).each(function(record) {

--- a/src/AppBundle/Resources/public/js/nrdb.js
+++ b/src/AppBundle/Resources/public/js/nrdb.js
@@ -282,7 +282,7 @@ function update_deck(options) {
 			order += ',faction_code';
 			break;
 		case 'number':
-			order = 'code';
+			order = ',code';
 			break;
 	}
 	order += ',title';

--- a/src/AppBundle/Resources/views/Builder/deckview.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deckview.html.twig
@@ -100,6 +100,7 @@ var Identity = null,
 			<li><a href="#" id="btn-sort-number"><label><input type="radio" name="sort-order">by Set</label></a></li>
 			<li><a href="#" id="btn-sort-faction"><label><input type="radio" name="sort-order">by Faction</label></a></li>
 			<li><a href="#" id="btn-sort-faction-type"><label><input type="radio" name="sort-order">by Faction, then Type</label></a></li>
+			<li><a href="#" id="btn-sort-faction-number"><label><input type="radio" name="sort-order">by Faction, then Set</label></a></li>
 			<li><a href="#" id="btn-sort-title"><label><input type="radio" name="sort-order">by Name</label></a></li>
     </ul>
   </div>

--- a/src/AppBundle/Resources/views/Decklist/decklist.html.twig
+++ b/src/AppBundle/Resources/views/Decklist/decklist.html.twig
@@ -101,6 +101,7 @@ NRDB.user.params.decklist_id = Decklist.id;
 					<li><a href="#" id="btn-sort-number">by Set</a></li>
 					<li><a href="#" id="btn-sort-faction">by Faction</a></li>
 					<li><a href="#" id="btn-sort-faction-type">by Faction, then Type</a></li>
+					<li><a href="#" id="btn-sort-faction-number">by Faction, then Set</a></li>
 					<li><a href="#" id="btn-sort-title">by Name</a></li>
 				</ul>
 			</div>


### PR DESCRIPTION
I have my Netrunner collection in binders, each faction having its own binder, then cards entered in order of release. I have used the browser console to add a matching sorting option, but I thought it might be a good feature for the site, so... here you go. 

As a sidenote, I must say I'm really impressed with the flexibility of your code here. It was so incredibly easy to add this option.
