### PR TITLE
fix the Professor for MWL 1.2

### DIFF
--- a/src/AppBundle/Resources/public/js/nrdb.js
+++ b/src/AppBundle/Resources/public/js/nrdb.js
@@ -201,9 +201,9 @@ function get_influence_penalty(card, qty) {
     }
     if (qty == null)
         qty = 1;
-    if (Identity.code == "03029" && card.type_code == "program" && qty <= 1) {
+    if (Identity.code == "03029" && card.type_code == "program" && qty > 0) {
         // The Professor: first program is free
-        return 0;
+        qty -= 1;
     }
     return qty * MWL.cards[card.code];
 }


### PR DESCRIPTION
Old implementation had a bug where if the quantity was more than 1, then the full influence cost was used.