### PR TITLE
Destroy every other qtip before creating a new one

### DIFF
--- a/src/AppBundle/Resources/public/js/nrdb.tip.js
+++ b/src/AppBundle/Resources/public/js/nrdb.tip.js
@@ -36,6 +36,11 @@
             image_svg = '<div class="card-image card-image-' + card.side_code + '-' + card.type_code + '"' + (card.imageUrl ? ' style="background-image:url(' + card.imageUrl + ')"' : '')
                     + '><svg width="103px" height="90px" viewBox="0 0 677 601" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><mask id="mask"><use xlink:href="#rect" style="fill:white" /><use xlink:href="#hex" style="fill:black"/></mask><use xlink:href="#rect" mask="url(#mask)"/><use xlink:href="#hex" style="stroke:black;fill:none;stroke-width:15" /></svg></div>';
         }
+
+        $('.qtip').each(function(){
+            $(this).qtip('api').destroy(true);
+        });
+
         $this.qtip(
                 {
                     content: {


### PR DESCRIPTION
With this PR, all qtips will be removed from the DOM before creating any new.
Tried setting hidden and blur events for qtips (http://qtip2.com/options#events), but did not work well.
Closes #119.