### PR TITLE
highlight doc & publish sql fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ When you update your repository (`git pull`), run the following commands:
 
 To update the deck of the week on the front page:
 
-- `php app/console highlight` 
+- `php app/console nrdb:highlight decklist_id` 
+
+where `decklist_id` is the numeric id of the deck you want to highlight.
 
 ## Setup an admin account
 

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -360,8 +360,10 @@ class SocialController extends Controller
         $packs = $dbh->executeQuery("SELECT DISTINCT
 				p.code code,
 				p.name name,
-        		y.code cycle_code,
-        		y.name cycle_name
+				p.position pack_position,
+				y.code cycle_code,
+				y.name cycle_name,
+				y.position cycle_position
 				from pack p
 				join cycle y on p.cycle_id=y.id
         		join card c on c.pack_id=p.id


### PR DESCRIPTION
Correct the highlight command documentation and fix a sql error when publishing a decklist.

SQL error was caused by ordering by fields not in the select.

The highlight command also needed the nrdb: prefix.