### PR TITLE
Fix adding comments on review page

### DIFF
--- a/src/AppBundle/Resources/views/Reviews/reviews.html.twig
+++ b/src/AppBundle/Resources/views/Reviews/reviews.html.twig
@@ -2,6 +2,7 @@
 
 {% block head %}
 <script src="{{ asset('/bundles/app/js/reviews.js') }}"></script>
+<script src="{{ asset('/bundles/app/js/zoom.js') }}"></script>
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
Currently the add comment link/button on the reviews page doesn't work because the relevant javascript is in zoom.js and only loaded when viewing a card's page. This bug manifests as the user's browser going to https://netrunnerdb.com/review/comment and getting a "Your comment is empty" error.

By adding zoom.js to the reviews page this is fixed. It does add some functions that are not needed for the reviews list so I'm not sure this is the optimal patch.