### PR TITLE
Add "latest pack at time of writing" to card reviews

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -315,7 +315,6 @@ class SearchController extends Controller
 				}
 				$cardinfo['available'] = $availability[$pack->getCode()];
 				if($view == "zoom") {
-					$allsetsdata = $this->get('cards_data')->allsetsdata();
 						$cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
 						$sets = $this->get('cards_data')->allsetsnocycledata();
 						foreach ($cardinfo['reviews'] as $key => $review) {

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -316,19 +316,6 @@ class SearchController extends Controller
 				$cardinfo['available'] = $availability[$pack->getCode()];
 				if($view == "zoom") {
 					$cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
-					$dbh = $this->get('doctrine')->getConnection();
-					foreach ($cardinfo['reviews'] as $key => $review) {
-						// Trouvez le dernier pack publié au moment de la création de l'avis
-						$rows = $dbh->executeQuery(
-							"SELECT name
-							FROM pack
-							WHERE date_release > ?
-							ORDER by date_release DESC
-							LIMIT 1",
-							array($review['date_creation']->format('U'))
-							)->fetchAll(\PDO::FETCH_ASSOC);
-						$cardinfo['reviews'][$key]['latestpack'] = $rows[0]['name'];
-					}
 					$cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
 				}
 				if($view == "rulings") {

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -317,17 +317,17 @@ class SearchController extends Controller
 				$cardinfo['available'] = $availability[$pack->getCode()];
 				if($view == "zoom") {
 					$allsetsdata = $this->get('cards_data')->allsetsdata();
-				    $cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
-                    $sets = $this->get('cards_data')->allsetsnocycledata();
-					foreach ($cardinfo['reviews'] as $key => $review) {
-						// Trouvez le dernier pack publié au moment de la création de l'avis
-                        foreach (array_reverse($sets) as $set) {
-                            if ($set['available'] < $review['date_creation']) {
-                                $cardinfo['reviews'][$key]['latestpack'] = $set['name'];
-                                break;
-                            }
-                            // Ne continue pas aux ensembles plus anciens
-                        }
+						$cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
+						$sets = $this->get('cards_data')->allsetsnocycledata();
+						foreach ($cardinfo['reviews'] as $key => $review) {
+							// Trouvez le dernier pack publié au moment de la création de l'avis
+							foreach (array_reverse($sets) as $set) {
+								if ($set['available'] < $review['date_creation']) {
+									$cardinfo['reviews'][$key]['latestpack'] = $set['name'];
+									// Ne continue pas aux ensembles plus anciens
+									break;
+								}
+							}
 					}
 					$cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
 				}

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -316,16 +316,18 @@ class SearchController extends Controller
 				$cardinfo['available'] = $availability[$pack->getCode()];
 				if($view == "zoom") {
 					$cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
-					$sets = $this->get('cards_data')->allsetsnocycledata();
+					$dbh = $this->get('doctrine')->getConnection();
 					foreach ($cardinfo['reviews'] as $key => $review) {
 						// Trouvez le dernier pack publié au moment de la création de l'avis
-						foreach (array_reverse($sets) as $set) {
-							if ($set['available'] < $review['date_creation']) {
-								$cardinfo['reviews'][$key]['latestpack'] = $set['name'];
-								// Ne continue pas aux ensembles plus anciens
-								break;
-							}
-						}
+						$rows = $dbh->executeQuery(
+							"SELECT name
+							FROM pack
+							WHERE date_release > ?
+							ORDER by date_release DESC
+							LIMIT 1",
+							array($review['date_creation']->format('U'))
+							)->fetchAll(\PDO::FETCH_ASSOC);
+						$cardinfo['reviews'][$key]['latestpack'] = $rows[0]['name'];
 					}
 					$cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
 				}

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -255,8 +255,8 @@ class SearchController extends Controller
 			'full' => 20,
 			'images' => 20,
 			'short' => 1000,
-                        'rulings' => 200,
-		    'zoom' => 1,
+			'rulings' => 200,
+			'zoom' => 1,
 		];
 		
 		$synonyms = [
@@ -315,12 +315,26 @@ class SearchController extends Controller
 				}
 				$cardinfo['available'] = $availability[$pack->getCode()];
 				if($view == "zoom") {
+					$allsetsdata = $this->get('cards_data')->allsetsdata();
 				    $cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
-                                    $cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
+					$dbh = $this->get('doctrine')->getConnection();
+					foreach ($cardinfo['reviews'] as $key => $review) {
+						// Trouvez le dernier pack publié au moment de la création de l'avis
+						$rows = $dbh->executeQuery(
+							"SELECT name
+							FROM pack
+							WHERE date_release > ?
+							ORDER by date_release DESC
+							LIMIT 1",
+							array($review['date_creation']->format('U'))
+							)->fetchAll(\PDO::FETCH_ASSOC);
+						$cardinfo['reviews'][$key]['latestpack'] = $rows[0]['name'];
+					}
+					$cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
 				}
-                                if($view == "rulings") {
-                                    $cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
-                                }
+				if($view == "rulings") {
+					$cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
+				}
 				$cards[] = $cardinfo;
 			}
 

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -315,17 +315,17 @@ class SearchController extends Controller
 				}
 				$cardinfo['available'] = $availability[$pack->getCode()];
 				if($view == "zoom") {
-						$cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
-						$sets = $this->get('cards_data')->allsetsnocycledata();
-						foreach ($cardinfo['reviews'] as $key => $review) {
-							// Trouvez le dernier pack publié au moment de la création de l'avis
-							foreach (array_reverse($sets) as $set) {
-								if ($set['available'] < $review['date_creation']) {
-									$cardinfo['reviews'][$key]['latestpack'] = $set['name'];
-									// Ne continue pas aux ensembles plus anciens
-									break;
-								}
+					$cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
+					$sets = $this->get('cards_data')->allsetsnocycledata();
+					foreach ($cardinfo['reviews'] as $key => $review) {
+						// Trouvez le dernier pack publié au moment de la création de l'avis
+						foreach (array_reverse($sets) as $set) {
+							if ($set['available'] < $review['date_creation']) {
+								$cardinfo['reviews'][$key]['latestpack'] = $set['name'];
+								// Ne continue pas aux ensembles plus anciens
+								break;
 							}
+						}
 					}
 					$cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
 				}

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -6,7 +6,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use AppBundle\AppBundle;
 use Symfony\Component\HttpFoundation\Request;
-use DateTime;
 
 class SearchController extends Controller 
 {

--- a/src/AppBundle/Resources/config/doctrine/Cycle.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Cycle.orm.yml
@@ -13,6 +13,7 @@ AppBundle\Entity\Cycle:
             orderBy: { 'position': 'ASC' }
             targetEntity: Pack
             mappedBy: cycle
+            fetch: EAGER
     manyToMany:
         rotations:
             targetEntity: Rotation

--- a/src/AppBundle/Resources/public/css/style.css
+++ b/src/AppBundle/Resources/public/css/style.css
@@ -411,6 +411,7 @@ article.review .review-like { float:left; font-size: 120%; width:50px }
 article.review .review-content { margin-left: 50px }
 article.review .review-text :first-child { margin-top: 0px }
 article.review .review-date { clear: both; text-align: right }
+article.review .review-latestpack { clear: both; text-align: right }
 article.review .review-author { text-align: right }
 article.review .review-comment { border-top: 1px solid #ddd; padding: 0.5em; }
 @media (min-width: 992px) {

--- a/src/AppBundle/Resources/views/Search/display-zoom.html.twig
+++ b/src/AppBundle/Resources/views/Search/display-zoom.html.twig
@@ -107,6 +107,9 @@
                                                 <div class="review-date">
                                                     <time datetime="{{ review.date_creation|date('c') }}">{{ review.date_creation|date('j M Y') }}</time>
                                                 </div>
+                                                <div class="review-latestpack">
+                                                    (<i>{{ review.latestpack }}</i> era)
+                                                </div>
                                                 <div class="review-author">
                                                     <a href="{{ path('user_profile_view', {user_id:review.author_id,user_name:review.author_name|e('url')}) }}" rel="author" class="username {{ review.author_color }}">{{ review.author_name }}</a>
                                                     {% if review.author_donation > 0 %}<span class="glyphicon glyphicon-gift donator" title="NetrunnerDB Gracious Donator"></span>{% endif %}

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -742,10 +742,20 @@ class CardsData {
         $reviews = $this->doctrine->getRepository('AppBundle:Review')->findBy(array('card' => $card), array('nbvotes' => 'DESC'));
 
         $response = array();
+        $sets = $this->allsetsnocycledata();
         foreach ($reviews as $review) {
             /* @var $review \AppBundle\Entity\Review */
             $user = $review->getUser();
             $date_creation = $review->getDatecreation();
+            // Trouvez le dernier pack publié au moment de la création de l'avis
+            $latest_pack = 'Unknown';
+            foreach (array_reverse($sets) as $set) {
+                if ($set['available'] < $date_creation) {
+                    $latest_pack = $set['name'];
+                    // Ne continue pas aux ensembles plus anciens
+                    break;
+                }
+            }
             $response[] = array(
                 'id' => $review->getId(),
                 'text' => $review->getText(),
@@ -757,6 +767,7 @@ class CardsData {
                 'date_creation' => $date_creation,
                 'nbvotes' => $review->getNbvotes(),
                 'comments' => $review->getComments(),
+                'latestpack' => $latest_pack,
             );
         }
 


### PR DESCRIPTION
Basically I would like to start to become familiar with this codebase, so I grabbed what seemed like a easy-ish issue to start with, choosing #150  as my victim. After this change, for each Review we will perform a SQL query to get the name of the most recently released pack at the time of the review creation, and pass that along in the review data. I'm attaching a screenshot of how it renders from my test instance. I also touched a couple of lines just to make their indentation match their neighbors more closely.
![capture](https://user-images.githubusercontent.com/1231665/31322419-21f3be7c-ac4c-11e7-814a-b60acb0740ad.PNG)

One yellow flag I noticed that is confusing me a bit, is that when I load the same page including this change it reports 80 db queries, whereas on master it only reports 11. Let me know if you'd like me to gather more info related to that.