### PR TITLE
Add MWL status to card zoom page

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -317,6 +317,7 @@ class SearchController extends Controller
 				if($view == "zoom") {
 					$cardinfo['reviews'] = $this->get('cards_data')->get_reviews($card);
 					$cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);
+					$cardinfo['mwl_info'] = $this->get('cards_data')->get_mwl_info($card);
 				}
 				if($view == "rulings") {
 					$cardinfo['rulings'] = $this->get('cards_data')->get_rulings($card);

--- a/src/AppBundle/Resources/public/css/style.css
+++ b/src/AppBundle/Resources/public/css/style.css
@@ -495,6 +495,11 @@ img[data-src] {
     cursor: pointer;
 }
 
+ul.msl-entries-list blockquote {
+    font-size: inherit;
+    padding: 5px 10px;
+}
+
 ul.rulings-list blockquote {
     font-size: inherit;
     padding: 5px 10px;

--- a/src/AppBundle/Resources/views/Search/display-zoom.html.twig
+++ b/src/AppBundle/Resources/views/Search/display-zoom.html.twig
@@ -63,6 +63,31 @@
                             </div>
                         </div>
                     </div>
+                    
+                    <div class="row">
+                        <div class="col-md-12 MWL Entries" style="margin-top:2em">
+                            <div style="ine-height:34px" class="mwl-entries-header">
+                                <span style="font-size:24px">MWL Entries</span>
+                                {% if card.mwl_info|length %}
+                                    <ul class="mwl-entries-list">
+                                        {% for mwl_info in card.mwl_info %}
+                                            {% if mwl_info.is_restricted == true %}
+                                                <li>{{ mwl_info.mwl_name }}{% if mwl_info.active %} (active){% endif %}: Restricted</li>
+                                            {% endif %}
+                                            {% if mwl_info.deck_limit is not null and mwl_info.deck_limit == 0 %}
+                                                <li>{{ mwl_info.mwl_name }}{% if mwl_info.active %} (active){% endif %}: Banned</li>
+                                            {% endif %}
+                                            {% if mwl_info.universal_faction_cost > 0 %}
+                                                <li>{{ mwl_info.mwl_name }}{% if mwl_info.active %} (active){% endif %}: {{ mwl_info.universal_faction_cost }} Universal Influence</li>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </ul>
+                                {% else %}
+                                    <p><i>No MWL Entries for this card.</i></p>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
 
                     <div class="row">
                         <div class="col-md-12 rulings" data-card-id="{{ card.id }}" style="margin-top:2em">

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -738,6 +738,31 @@ class CardsData {
         ));
     }
 
+    public function get_mwl_info($card) {
+        $response = array();
+        $card_code = $card->getCode();
+        $mwls = $this->doctrine->getRepository('AppBundle:Mwl')->findBy(array(), array("dateStart" => "DESC"));
+        foreach ($mwls as $mwl) {
+            $mwl_cards = $mwl->getCards();
+            if (isset($mwl_cards[$card_code])) {
+                $card_mwl = $mwl_cards[$card_code];
+                $is_restricted = $card_mwl['is_restricted'] ?? 0;
+                $deck_limit = $card_mwl['deck_limit'] ?? null;
+                // Ceux-ci signifient la même chose
+                $universal_faction_cost = $card_mwl['universal_faction_cost'] ?? $card_mwl['global_penalty'] ?? 0;
+                $response[] = array(
+                    'mwl_name' => $mwl->getName(),
+                    'active' => $mwl->getActive(),
+                    'is_restricted' => $is_restricted,
+                    'deck_limit' => $deck_limit,
+                    'universal_faction_cost' => $universal_faction_cost,
+                );
+            }
+        }
+
+        return $response;
+    }
+
     public function get_reviews($card) {
         $reviews = $this->doctrine->getRepository('AppBundle:Review')->findBy(array('card' => $card), array('nbvotes' => 'DESC'));
 


### PR DESCRIPTION
This is intended to address #14 . What it does:

- Display if the card is restricted
- Display if the card is banned (with flexible wording in case it's needed)

What it doesn't do:

- Display rotation status

Questions I have:

1. formatting - I think it's terrible right now, but I'm not sure what will look better. Should I just play around with it a bit more, or are there guidelines I should apply?
2. Ban wording - would it make more sense to just say "banned" instead of worrying about the specific deck limit? That would be an easy change
3. i18n - Is there some framework for this I should be tapping into?

Screenshots:
<img width="487" alt="screenshot 2017-10-13 15 07 09" src="https://user-images.githubusercontent.com/1231665/31587049-4a59317e-b18f-11e7-80d1-b37137f0c6b7.png">
<img width="490" alt="screenshot 2017-10-13 15 07 18" src="https://user-images.githubusercontent.com/1231665/31587051-4a730c98-b18f-11e7-9b1c-718be5f44d03.png">
<img width="495" alt="screenshot 2017-10-13 15 07 24" src="https://user-images.githubusercontent.com/1231665/31587052-4a9e5894-b18f-11e7-9a20-4a58fa46f635.png">
<img width="500" alt="screenshot 2017-10-13 15 07 30" src="https://user-images.githubusercontent.com/1231665/31587053-4ab7cc3e-b18f-11e7-8e66-12de60018737.png">
