### PR TITLE
fix setting MWL, in particular to "Casual"

### DIFF
--- a/src/AppBundle/Resources/views/Builder/deck.html.twig
+++ b/src/AppBundle/Resources/views/Builder/deck.html.twig
@@ -104,7 +104,7 @@ var Filters = {},
 				{{ mwl.name }}{% if not mwl.active %}{% if mwl.dateStart %} (after {{ mwl.dateStart|date('Y-m-d') }}){% endif %}{% else %} (active){% endif %}
 			</option>
 		    {% endfor %}
-		    <option value="">Casual Play</option>
+		    <option value=""{% if deck.mwl_code == null %} selected="selected"{% endif %}>Casual Play</option>
 		</select>
 	</div>
 	<button type="submit" class="btn btn-warning">Save</button>

--- a/src/AppBundle/Service/Decks.php
+++ b/src/AppBundle/Service/Decks.php
@@ -218,6 +218,8 @@ class Decks
             if ($mwl) {
             	$deck->setMwl($mwl);
             }
+        } else {
+        	$deck->setMwl(null);
         }
         
         $deck->setName($name);


### PR DESCRIPTION
This is a fix for the issue described in https://www.reddit.com/r/Netrunner/comments/7i9hlr/netrunnerdb_is_not_letting_me_switch_deck/ - previously it was impossible to reset a deck from any MWL version back to casual. Also and adding to the confusion, the MWL dropdown did not show "Casual" when the deck was in fact for casual play.