### PR TITLE
Preserve MWL Info

### DIFF
--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -843,11 +843,13 @@ class BuilderController extends Controller
         foreach ($decklist->getSlots() as $slot) {
             $content[$slot->getCard()->getCode()] = $slot->getQuantity();
         }
+		$mwl = $decklist->getMwl();
         return $this->forward('AppBundle:Builder:save',
                 array(
                         'name' => $decklist->getName(),
                         'content' => json_encode($content),
                         'decklist_id' => $decklist_id,
+						'mwl_code' => $mwl == null ? null : $mwl->getCode(),
                 ));
     
     }

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -72,7 +72,7 @@ class SocialController extends Controller
                 ));
                 $response->setData([
                     'allowed' => TRUE,
-                    'message' => 'This deck is <a href="' + $url + '">already published</a>. Are you sure you want to publish a duplicate?',
+                    'message' => 'This deck is <a href="' . $url . '">already published</a>. Are you sure you want to publish a duplicate?',
                 ]);
                 return $response;
             }
@@ -150,6 +150,7 @@ class SocialController extends Controller
         $decklist->setModerationStatus(Decklist::MODERATION_PUBLISHED);
         $decklist->setTournament($tournament);
         $decklist->setIsLegal(true);
+		$decklist->setMwl($deck->getMwl());
         foreach($deck->getSlots() as $slot) {
             $card = $slot->getCard();
             $decklistslot = new Decklistslot();

--- a/src/AppBundle/Entity/Decklist.php
+++ b/src/AppBundle/Entity/Decklist.php
@@ -36,7 +36,8 @@ class Decklist implements \Serializable
                             'user_id' => $this->user->getId(),
                             'user_name' => $this->user->getUsername(),
                             'tournament_badge' => $this->tournament ? true : false,
-                            'cards' => $cards
+                            'cards' => $cards,
+							'mwl_code' => $this->mwl ? $this->mwl->getCode() : null,
             ];
     }
 
@@ -1103,4 +1104,33 @@ class Decklist implements \Serializable
         return $this;
     }
 
+    /**
+     * @var \AppBundle\Entity\Mwl
+     */
+    private $mwl;
+
+
+    /**
+     * Set mwl
+     *
+     * @param \AppBundle\Entity\Mwl $mwl
+     *
+     * @return Decklist
+     */
+    public function setMwl(\AppBundle\Entity\Mwl $mwl = null)
+    {
+        $this->mwl = $mwl;
+
+        return $this;
+    }
+
+    /**
+     * Get mwl
+     *
+     * @return \AppBundle\Entity\Mwl
+     */
+    public function getMwl()
+    {
+        return $this->mwl;
+    }
 }

--- a/src/AppBundle/Resources/config/doctrine/Decklist.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Decklist.orm.yml
@@ -79,6 +79,12 @@ AppBundle\Entity\Decklist:
             joinColumn:
                 name: rotation_id
                 referencedColumnName: id
+        mwl:
+            targetEntity: Mwl
+            nullable: true
+            joinColumn:
+                name: mwl_id
+                referencedColumnName: id
     oneToMany:
         slots:
             targetEntity: Decklistslot


### PR DESCRIPTION
This adds an `mwl_id` field to the decklist table, so that the MWL info of a deck is preserved across "publish deck" and "copy to my decks" actions.