### PR TITLE
add og:image for FB sharing

### DIFF
--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -14,6 +14,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="mobile-web-app-capable" content="yes">
+    <meta property="og:image" content="https://netrunnerdb.com/icon.png" />
     {% if pagedescription is defined %}<meta name="description" content="{{ pagedescription }}">{% endif %}
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css">


### PR DESCRIPTION
Gives a hint to FB which image to use when sharing links. Currently they often pick the US Flag icon, which is kinda inappropriate.

@Alsciende when you deploy this, could you also run the `app:legality` commands for the MWL 2.1 update (see #202)?