### PR TITLE
Remove text filter from filter query when user clears filter textbox

### DIFF
--- a/web/js/nrdb.smart_filter.js
+++ b/web/js/nrdb.smart_filter.js
@@ -1,10 +1,14 @@
 (function(smart_filter, $) {
 	var SmartFilterQuery = [];
-	
+
 	smart_filter.get_query = function(FilterQuery) {
-		return _.extend(FilterQuery, SmartFilterQuery);
+        var query = _.extend(FilterQuery, SmartFilterQuery);
+        if (!SmartFilterQuery.text) {
+            delete query.text;
+        }
+        return query;
 	};
-	
+
 	smart_filter.handler = function (value, callback) {
 		var conditions = filterSyntax(value);
 		SmartFilterQuery = {};
@@ -69,7 +73,7 @@
 
 		callback();
 	};
-	
+
 	function add_integer_sf(key, operator, values) {
 		for (var j = 0; j < values.length; j++) {
 			values[j] = parseInt(values[j], 10);
@@ -198,5 +202,5 @@
 		return list;
 	}
 
-	
+
 })(NRDB.smart_filter = {}, jQuery);


### PR DESCRIPTION
This is intended as a fix for #234.

I noticed that the `_.extend()` call wasn't removing the `text` property from the filter query if the user deleted all of the text from the filter text box, so this quite simply does that.

I am not a web developer by trade, so I apologize if this is not a proper or elegant solution.