### PR TITLE
allow moderators to delete comments on any decklist

### DIFF
--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use AppBundle\Entity\Legality;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class SocialController extends Controller
 {
@@ -585,11 +586,11 @@ class SocialController extends Controller
      *
      * @ParamConverter("comment", class="AppBundle:Comment", options={"id" = "comment_id"})
      */
-    public function hidecommentAction(Comment $comment, int $hidden, EntityManagerInterface $entityManager)
+    public function hidecommentAction(Comment $comment, int $hidden, EntityManagerInterface $entityManager, AuthorizationCheckerInterface $authorizationChecker)
     {
         $user = $this->getUser();
 
-        if ($comment->getDecklist()->getUser()->getId() !== $user->getId()) {
+        if ($comment->getDecklist()->getUser()->getId() !== $user->getId() && !$authorizationChecker->isGranted('ROLE_MODERATOR')) {
             throw $this->createAccessDeniedException();
         }
 

--- a/web/js/decklist.js
+++ b/web/js/decklist.js
@@ -197,7 +197,7 @@ function setup_title() {
 }
 
 function setup_comment_hide() {
-    if(NRDB.user.data.is_author) {
+    if(NRDB.user.data.is_author || NRDB.user.data.is_moderator) {
         $('.comment-hide-button').remove();
         $('<a href="#" class="comment-hide-button"><span class="text-danger glyphicon glyphicon-remove" style="margin-left:.5em"></span></a>').appendTo('.collapse.in > .comment-date').on('click', function (event) {
             if(confirm('Do you really want to hide this comment for everybody?')) {


### PR DESCRIPTION
The 'About' page states that moderators should be able to delete comments as well as decklists. This pull request actually implements that feature, which would be useful on occasions when neither a decklist's author nor the site admin are promptly available to handle offensive posts.

I tested the client-side delete button stuff using element inspector just enough to find the server-side access check, but stopped short of actually building a local server instance, so if I missed any cases, please let me know.