### PR TITLE
Request cardgamedb images from http not https

### DIFF
--- a/src/AppBundle/Command/ImportImagesCommand.php
+++ b/src/AppBundle/Command/ImportImagesCommand.php
@@ -53,7 +53,7 @@ class ImportImagesCommand extends ContainerAwareCommand
             }
 
             $url = sprintf(
-                'https://www.cardgamedb.com/forums/uploads/an/med_ADN%d_%s.png',
+                'http://www.cardgamedb.com/forums/uploads/an/med_ADN%d_%s.png',
                 $ffgId,
                 $position
             );


### PR DESCRIPTION
Quick fix for https://github.com/Alsciende/netrunnerdb/issues/242

_Small disclaimer: I am a fledgeling web-developer, so I might not have seen the bigger picture here._

The `https` was added to prevent mixed content warnings, but now image requests to cardgamedb fail somehow. Changing it back to `http` works, but yeah, merge at your own discretion regarding the warnings.