### PR TITLE
Deckbuilder fixes

### DIFF
--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -17,36 +17,35 @@ function getDisplayDescriptions(sort) {
     var dd = {
         'type': [
             [// first column
-
                 {
                     id: 'event',
                     label: 'Event',
                     image: '/images/types/event.png',
                 }, {
-                id: 'hardware',
-                label: 'Hardware',
-                image: '/images/types/hardware.png',
-            }, {
-                id: 'resource',
-                label: 'Resource',
-                image: '/images/types/resource.png',
-            }, {
-                id: 'agenda',
-                label: 'Agenda',
-                image: '/images/types/agenda.png',
-            }, {
-                id: 'asset',
-                label: 'Asset',
-                image: '/images/types/asset.png',
-            }, {
-                id: 'upgrade',
-                label: 'Upgrade',
-                image: '/images/types/upgrade.png',
-            }, {
-                id: 'operation',
-                label: 'Operation',
-                image: '/images/types/operation.png',
-            },
+                    id: 'hardware',
+                    label: 'Hardware',
+                    image: '/images/types/hardware.png',
+                }, {
+                    id: 'resource',
+                    label: 'Resource',
+                    image: '/images/types/resource.png',
+                }, {
+                    id: 'agenda',
+                    label: 'Agenda',
+                    image: '/images/types/agenda.png',
+                }, {
+                    id: 'asset',
+                    label: 'Asset',
+                    image: '/images/types/asset.png',
+                }, {
+                    id: 'upgrade',
+                    label: 'Upgrade',
+                    image: '/images/types/upgrade.png',
+                }, {
+                    id: 'operation',
+                    label: 'Operation',
+                    image: '/images/types/operation.png',
+                },
             ],
             [// second column
                 {
@@ -54,30 +53,30 @@ function getDisplayDescriptions(sort) {
                     label: 'Icebreaker',
                     image: '/images/types/program.png',
                 }, {
-                id: 'program',
-                label: 'Program',
-                image: '/images/types/program.png',
-            }, {
-                id: 'barrier',
-                label: 'Barrier',
-                image: '/images/types/ice.png',
-            }, {
-                id: 'code-gate',
-                label: 'Code Gate',
-                image: '/images/types/ice.png',
-            }, {
-                id: 'sentry',
-                label: 'Sentry',
-                image: '/images/types/ice.png',
-            }, {
-                id: 'multi',
-                label: 'Multi',
-                image: '/images/types/ice.png',
-            }, {
-                id: 'none',
-                label: 'Other',
-                image: '/images/types/ice.png',
-            },
+                    id: 'program',
+                    label: 'Program',
+                    image: '/images/types/program.png',
+                }, {
+                    id: 'barrier',
+                    label: 'Barrier',
+                    image: '/images/types/ice.png',
+                }, {
+                    id: 'code-gate',
+                    label: 'Code Gate',
+                    image: '/images/types/ice.png',
+                }, {
+                    id: 'sentry',
+                    label: 'Sentry',
+                    image: '/images/types/ice.png',
+                }, {
+                    id: 'multi',
+                    label: 'Multi',
+                    image: '/images/types/ice.png',
+                }, {
+                    id: 'none',
+                    label: 'Other',
+                    image: '/images/types/ice.png',
+                },
             ],
         ],
         'faction': [
@@ -252,6 +251,12 @@ function find_identity() {
     Identity = NRDB.data.cards.find({ indeck: { '$gt': 0 }, type_code: 'identity' }).pop();
 }
 
+function unicorn(card) {
+    var mwlCard = get_mwl_modified_card(card);
+    var unicorn_emoji = '<span title="Restricted card" style="display:inline-block;width:1.5em;">🦄</span> ';
+    return mwlCard.is_restricted ? unicorn_emoji : '';
+}
+
 function update_deck(options) {
     var restrainOneColumn = false;
     if (options) {
@@ -312,7 +317,8 @@ function update_deck(options) {
     InfluenceLimit = 0;
     var cabinet = {};
     var parts = Identity.title.split(/: /);
-    $('#identity').html('<a href="' + Routing.generate('cards_zoom', { card_code: Identity.code }) + '" data-target="#cardModal" data-remote="false" class="card" data-toggle="modal" data-index="' + Identity.code + '">' + parts[0] + ' <small>' + parts[1] + '</small></a>');
+
+    $('#identity').html('<a href="' + Routing.generate('cards_zoom', { card_code: Identity.code }) + '" data-target="#cardModal" data-remote="false" class="card" data-toggle="modal" data-index="' + Identity.code + '">' + parts[0] + ' <small>' + parts[1] + '</small></a>' + unicorn(Identity));
     $('#img_identity').prop('src', Identity.imageUrl);
     InfluenceLimit = Identity.influence_limit;
     if (typeof InfluenceLimit === "undefined")
@@ -416,9 +422,7 @@ function update_deck(options) {
             additional_info = '(<span class="small icon icon-' + card.pack.cycle.code + '"></span> ' + card.position + ') ' + alert_number_of_sets + influence;
         }
 
-        var mwlCard = get_mwl_modified_card(card);
-        var unicorn = mwlCard.is_restricted ? '<span title="Restricted card" style="display:inline-block;width:1.5em;">🦄</span> ' : '';
-        var item = $('<div>' + card.indeck + 'x <a href="' + Routing.generate('cards_zoom', { card_code: card.code }) + '" class="card" data-toggle="modal" data-remote="false" data-target="#cardModal" data-index="' + card.code + '">' + card.title + '</a> ' + unicorn + additional_info + '</div>');
+        var item = $('<div>' + card.indeck + 'x <a href="' + Routing.generate('cards_zoom', { card_code: card.code }) + '" class="card" data-toggle="modal" data-remote="false" data-target="#cardModal" data-index="' + card.code + '">' + card.title + '</a> ' + unicorn(card) + additional_info + '</div>');
         item.appendTo($('#deck-content .deck-' + criteria));
 
         cabinet[criteria] |= 0;
@@ -466,7 +470,7 @@ function test_cacherefresh() {
         accepted_cards = [];
 
     // core set check
-    NRDB.data.cards.find({ indeck: { '$gt': 0 }, pack_code: 'core2' }).forEach(function (card) {
+    NRDB.data.cards.find({ indeck: { '$gt': 0 }, pack_code: 'sc19' }).forEach(function (card) {
         if (card.indeck <= card.quantity) {
             accepted_cards.push(card.code);
         }
@@ -482,7 +486,7 @@ function test_cacherefresh() {
     // deluxe and last-two-cycles check
     var remaining_cards = NRDB.data.cards.find({
         indeck: { '$gt': 0 },
-        pack_code: { '$ne': 'core2' },
+        pack_code: { '$ne': 'sc19' },
         code: { '$nin': accepted_cards },
     });
     var packs = _.values(_.reduce(remaining_cards, function (acc, card) {
@@ -542,10 +546,15 @@ function test_onesies() {
         return b.count - a.count;
     });
     var core = _.find(packs, function (element) {
-        return element.pack.code === 'core' || element.pack.code === 'core2';
+        return element.pack.code === 'core' ||
+               element.pack.code === 'core2' ||
+               element.pack.code === 'sc19';
     });
     var deluxe = _.find(packs, function (element) {
-        return element.pack.cycle.size === 1 && element.pack.code !== 'core' && element.pack.code !== 'core2';
+        return element.pack.cycle.size === 1 &&
+               element.pack.code !== 'core' &&
+               element.pack.code !== 'core2' &&
+               element.pack.code !== 'sc19';
     });
     var datapack = _.find(packs, function (element) {
         return element.pack.cycle.size > 1;
@@ -706,45 +715,90 @@ function check_rotation() {
     var intersect = rotated_cycles.filter(function(n) {
         return used_cycles.indexOf(n) !== -1;
     });
-    
+
     if (intersect.length > 0) {
-        $('#rotated').html('Deck contains rotated cards - <a href="javascript:convert_to_rcs()" title="Attempt to replace rotated cards with their post-rotation counterparts.">click to update</a>').show();
+        $('#rotated').html('Deck contains rotated cards - <a href="javascript:convert_to_recent()" title="Attempt to replace rotated cards with their post-rotation counterparts.">click to update</a>').show();
     } else {
         $('#rotated').text('').hide();
     }
 }
 
-function convert_to_rcs() {
+function convert_to_recent() {
     var old2new = {
-        "02006": "20030", "01039": "20046", "02013": "20075", "02106": "20039", "01056": "20064", "01034": "20038", "02082": "20018", "01057": "20065", "02094": "20103", "01029": "20033",
-        "01050": "20056", "01104": "20089", "01070": "20098", "02080": "20124", "04099": "20083", "01106": "20125", "01025": "20027", "01008": "20009", "01026": "20029", "01037": "20044",
-        "02047": "20042", "01011": "20013", "01112": "20130", "02070": "20073", "01094": "20078", "01064": "20069", "01030": "20034", "01004": "20005", "01046": "20051", "02086": "20031",
-        "01078": "20102", "04036": "20080", "01091": "20122", "02117": "20114", "02014": "20094", "01005": "20006", "02105": "20036", "01044": "20050", "01053": "20059", "04010": "20062",
-        "01035": "20040", "01063": "20070", "02019": "20085", "01036": "20043", "01077": "20100", "01068": "20095", "02048": "20045", "01062": "20068", "01069": "20096", "01067": "20093",
-        "01047": "20052", "02104": "20028", "04093": "20104", "01108": "20127", "01109": "20128", "02004": "20014", "02056": "20115", "01019": "20020", "01103": "20088", "01020": "20022",
-        "01085": "20120", "01060": "20074", "01072": "20106", "01087": "20112", "02097": "20123", "01043": "20049", "04106": "20035", "01017": "20019", "04037": "20082", "02018": "20079",
-        "02051": "20063", "04091": "20076", "01107": "20126", "01113": "20131", "01110": "20132", "02101": "20003", "02010": "20061", "02003": "20011", "01098": "20090", "01090": "20116",
-        "04041": "20001", "01049": "20055", "04075": "20111", "02063": "20017", "01083": "20118", "02028": "20057", "01058": "20071", "01100": "20092", "01080": "20109", "02069": "20060",
-        "01102": "20086", "04117": "20087", "02115": "20110", "01028": "20032", "01086": "20121", "04033": "20101", "02118": "20081", "01040": "20047", "01088": "20113", "02026": "20041",
-        "04096": "20117", "02043": "20021", "01093": "20077", "04079": "20091", "02064": "20025", "01084": "20119", "01101": "20084", "01111": "20129", "01051": "20058", "02033": "20107",
-        "02102": "20008", "01022": "20024", "01021": "20023", "02067": "20053", "04101": "20004", "01015": "20015", "02062": "20010", "04012": "20105", "01003": "20002", "02085": "20026",
-        "01042": "20048", "01048": "20054", "02002": "20007", "04013": "20099", "04051": "20067", "01061": "20066", "02022": "20016", "02112": "20097", "04082": "20012", "02095": "20108",
-        "01059": "20072", "02046": "20037",
-        
+        "01004": "25007", "01005": "25008", "01007": "25010", "01008": "25011",
+        "01011": "25015", "01015": "25016", "01017": "25020", "01019": "25023",
+        "01021": "25026", "01022": "25030", "01026": "25036", "01028": "25037",
+        "01029": "25038", "01031": "25039", "01034": "25042", "01035": "25043",
+        "01036": "25046", "01037": "25047", "01038": "25048", "01042": "25052",
+        "01043": "25054", "01046": "25055", "01047": "25056", "01050": "25059",
+        "01051": "25061", "01053": "25062", "01056": "25070", "01057": "25071",
+        "01058": "25079", "01059": "25080", "01061": "25074", "01062": "25075",
+        "01063": "25078", "01064": "25076", "01067": "25084", "01068": "25087",
+        "01069": "25089", "01070": "25091", "01072": "25101", "01077": "25095",
+        "01078": "25098", "01080": "25104", "01084": "25117", "01085": "25118",
+        "01086": "25119", "01087": "25109", "01088": "25112", "01090": "25115",
+        "01091": "25121", "01093": "25122", "01094": "25124", "01098": "25136",
+        "01101": "25130", "01102": "25132", "01103": "25134", "01106": "25141",
+        "01109": "25142", "01110": "25146", "01111": "25143", "01112": "25144",
+        "01113": "25145", "02003": "25013", "02010": "25066", "02013": "25082",
+        "02018": "25126", "02019": "25131", "02022": "25017", "02026": "25044",
+        "02031": "25085", "02032": "25086", "02033": "25102", "02043": "25024",
+        "02046": "25040", "02047": "25045", "02048": "25049", "02051": "25068",
+        "02055": "25110", "02056": "25114", "02062": "25012", "02063": "25018",
+        "02066": "25053", "02079": "25137", "02082": "25019", "02084": "25028",
+        "02085": "25031", "02091": "25065", "02095": "25103", "02101": "25005",
+        "02104": "25035", "02107": "25050", "02110": "25073", "02112": "25090",
+        "02115": "25107", "02117": "25113", "03028": "25041", "03040": "25051",
+        "03049": "25058", "03051": "25057", "03052": "25060", "04004": "25025",
+        "04009": "25064", "04012": "25100", "04013": "25093", "04033": "25096",
+        "04037": "25128", "04041": "25001", "04054": "25092", "04074": "25097",
+        "04079": "25138", "04081": "25004", "04090": "25081", "04093": "25099",
+        "04096": "25116", "04102": "25003", "05006": "25088", "05035": "25027",
+        "06003": "25094", "06014": "25014", "06048": "25139", "06052": "25002",
+        "06066": "25111", "06068": "25123", "06086": "25108", "06095": "25021",
+        "06120": "25063", "08023": "25022", "08033": "25077", "08058": "25125",
+        "08078": "25127", "08079": "25135", "08094": "25106", "08115": "25120",
+        "08117": "25129", "09003": "25105", "10001": "25006", "13003": "25029",
+        "13006": "25033", "13008": "25034", "13028": "25067", "13031": "25069",
+        "13033": "25072", "13040": "25083", "13050": "25133", "13053": "25140",
+        "13057": "25147", "20001": "25001", "20003": "25005", "20005": "25007",
+        "20006": "25008", "20009": "25011", "20010": "25012", "20011": "25013",
+        "20013": "25015", "20015": "25016", "20016": "25017", "20017": "25018",
+        "20018": "25019", "20019": "25020", "20020": "25023", "20021": "25024",
+        "20023": "25026", "20024": "25030", "20026": "25031", "20028": "25035",
+        "20029": "25036", "20032": "25037", "20033": "25038", "20037": "25040",
+        "20038": "25042", "20040": "25043", "20041": "25044", "20042": "25045",
+        "20043": "25046", "20044": "25047", "20045": "25049", "20048": "25052",
+        "20049": "25054", "20051": "25055", "20052": "25056", "20056": "25059",
+        "20058": "25061", "20059": "25062", "20061": "25066", "20063": "25068",
+        "20064": "25070", "20065": "25071", "20066": "25074", "20068": "25075",
+        "20069": "25076", "20070": "25078", "20071": "25079", "20072": "25080",
+        "20075": "25082", "20077": "25122", "20078": "25124", "20079": "25126",
+        "20082": "25128", "20084": "25130", "20085": "25131", "20086": "25132",
+        "20088": "25134", "20090": "25136", "20091": "25138", "20093": "25084",
+        "20095": "25087", "20096": "25089", "20097": "25090", "20098": "25091",
+        "20099": "25093", "20100": "25095", "20101": "25096", "20102": "25098",
+        "20104": "25099", "20105": "25100", "20106": "25101", "20107": "25102",
+        "20108": "25103", "20109": "25104", "20110": "25107", "20112": "25109",
+        "20113": "25112", "20114": "25113", "20115": "25114", "20116": "25115",
+        "20117": "25116", "20119": "25117", "20120": "25118", "20121": "25119",
+        "20122": "25121", "20125": "25141", "20128": "25142", "20129": "25143",
+        "20130": "25144", "20131": "25145", "20132": "25146", "22004": "25009",
+        "22010": "25032"
     }
     var cards_used = Object.keys(Deck);
-    var replaced = 0;    
+    var replaced = 0;
     cards_used.forEach(function(oldCode) {
         var newCode = old2new[oldCode];
 
         if (newCode) {
             var quantity = Deck[oldCode];
-        	NRDB.data.cards.updateById(newCode, {
-        		indeck : quantity
-        	});
-        	NRDB.data.cards.updateById(oldCode, {
-        		indeck : 0
-        	});
+            NRDB.data.cards.updateById(newCode, {
+                indeck : quantity
+            });
+            NRDB.data.cards.updateById(oldCode, {
+                indeck : 0
+            });
             ++replaced;
             Deck_changed_since_last_autosave = true;
         }


### PR DESCRIPTION
* Moves "unicorn" check to function, generating for IDs now
* Updates `convert_to_rcs` to `convert_to_recent`, updates card list for System Core 2019
* Adds System Core 2019 to Onesies and Cache Refresh
* Cleans up indentation and trailing spaces