### PR TITLE
Include card pack names in decklist search

### DIFF
--- a/app/Resources/views/Search/card.html.twig
+++ b/app/Resources/views/Search/card.html.twig
@@ -1,5 +1,5 @@
 <p class="background-{{ faction_code }}-20"
 	style="padding: 3px 5px; border-radius: 3px; border: 1px solid silver">
 	<button type="button" class="close" aria-hidden="true" onclick="$(this).parent('p').remove()">&times;</button>
-	<input type="hidden" name="cards[]" value="{{ code }}">{{ title }} ({{ pack.name }})
+	<input type="hidden" name="cards[]" value="{{ code }}">{{ title }} ({{ pack_name }})
 </p>

--- a/app/Resources/views/Search/card.html.twig
+++ b/app/Resources/views/Search/card.html.twig
@@ -1,5 +1,5 @@
 <p class="background-{{ faction_code }}-20"
 	style="padding: 3px 5px; border-radius: 3px; border: 1px solid silver">
 	<button type="button" class="close" aria-hidden="true" onclick="$(this).parent('p').remove()">&times;</button>
-	<input type="hidden" name="cards[]" value="{{ code }}">{{ title }}
+	<input type="hidden" name="cards[]" value="{{ code }}">{{ title }} ({{ pack.name }})
 </p>

--- a/src/AppBundle/Controller/DecklistsController.php
+++ b/src/AppBundle/Controller/DecklistsController.php
@@ -339,9 +339,11 @@ class DecklistsController extends Controller
                 "SELECT
     				c.title,
     				c.code,
-                                f.code faction_code
+                                f.code faction_code,
+                                p.name pack_name
     				FROM card c
                                 JOIN faction f ON f.id=c.faction_id
+                                JOIN pack p ON p.id=c.pack_id
                                 WHERE c.code IN (?)
     				ORDER BY c.code DESC",
                 [$cards_code],

--- a/web/js/search.js
+++ b/web/js/search.js
@@ -2,18 +2,18 @@ $(document).on('data.app', function() {
 	function findMatches(q, cb) {
 		if(q.match(/^\w:/)) return;
 		var matches = NRDB.data.cards.find({title: new RegExp(q, 'i')}).map(function (card) {
-			return { value: card.title };
+			return card;
 		});
 		cb(matches);
 	}
-	
+
 	$('#card').typeahead({
 		  hint: true,
 		  highlight: true,
 		  minLength: 3
 		},{
 		name : 'cardnames',
-		displayKey: 'value',
+		display: function (card) { return card.title + ' (' + card.pack.name + ')' },
 		source: findMatches
 	});
 });
@@ -24,28 +24,25 @@ function handle_checkbox_change() {
 }
 
 $(function() {
-	$('#card').on('typeahead:selected typeahead:autocompleted', function(event, data) {
-		console.log(data);
-		var card = NRDB.data.cards.find({
-			title : data.value
-		}).pop();
+	$('#card').on('typeahead:selected typeahead:autocompleted', function(event, card) {
+		console.log(card);
 		var line = $('<p class="background-'+card.faction_code+'-20" style="padding: 3px 5px;border-radius: 3px;border: 1px solid silver"><button type="button" class="close" aria-hidden="true">&times;</button><input type="hidden" name="cards[]" value="'+card.code+'">'+
-				  card.title + '</p>');
+				  card.title + ' (' + card.pack.name + ')</p>');
 		line.on({
 			click: function(event) { line.remove(); }
 		});
 		line.insertBefore($('#card'));
 		$(event.target).typeahead('val', '');
 	});
-	
+
 	$('#allowed_packs').on('change', handle_checkbox_change);
-	
+
 	$('#select_all').on('click', function (event) {
 		$('#allowed_packs').find('input[type="checkbox"]:not(:checked)').prop('checked', true);
 		handle_checkbox_change();
 		return false;
 	});
-	
+
 	$('#select_none').on('click', function (event) {
 		$('#allowed_packs').find('input[type="checkbox"]:checked').prop('checked', false);
 		handle_checkbox_change();


### PR DESCRIPTION
Fixes the typeahead search to include pack names in the description. Also uses the selected card for search instead of searching again by the selected cards name (this prevented searches for old versions of a card).

Closes #259 