### PR TITLE
Added placeholder text for Decklist name in Decklist search.

### DIFF
--- a/app/Resources/views/Search/form.html.twig
+++ b/app/Resources/views/Search/form.html.twig
@@ -54,7 +54,8 @@
             </div>
             <div class="form-group">
                 <label for="">Decklist name</label> <input type="text"
-                                                           class="form-control" id="title" name="title" value="{{ title }}">
+                                                           class="form-control" id="title" name="title" 
+                                                           placeholder="Enter decklist name" value="{{ title }}">
             </div>
             <div class="form-group">
                 <label for="is_legal">Tournament Legal</label>


### PR DESCRIPTION
Currently, the "Decklist name" field on the Decklist search page has no placeholder text, making it inconsistent with the other text fields like "Cards used" or "Author name":

![image](https://user-images.githubusercontent.com/10621139/49346429-4cd8da80-f68a-11e8-9f3b-763ded73803f.png)

This PR corrects this:

![image](https://user-images.githubusercontent.com/10621139/49346437-667a2200-f68a-11e8-9560-6890f8169b3d.png)