### PR TITLE
Allow publishing decks even when they contain unreleased cards

### DIFF
--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -48,15 +48,6 @@ class SocialController extends Controller
             throw $this->createAccessDeniedException();
         }
 
-        $lastPack = $deck->getLastPack();
-        if (!$lastPack->getDateRelease() || $lastPack->getDateRelease() > new \DateTime()) {
-            $response->setData([
-                'allowed' => false,
-                'message' => "You cannot publish this deck yet, because it has unreleased cards.",
-            ]);
-
-            return $response;
-        }
         $analyse = $judge->analyse($deck->getSlots()->toArray());
 
         if (is_string($analyse)) {
@@ -115,11 +106,6 @@ class SocialController extends Controller
         /** @var Deck $deck */
         $deck = $entityManager->getRepository('AppBundle:Deck')->find($deck_id);
         if ($this->getUser()->getId() != $deck->getUser()->getId()) {
-            throw $this->createAccessDeniedException();
-        }
-
-        $lastPack = $deck->getLastPack();
-        if (!$lastPack->getDateRelease() || $lastPack->getDateRelease() > new \DateTime()) {
             throw $this->createAccessDeniedException();
         }
 


### PR DESCRIPTION
Currently, NRDB does not allow publishing decks that contain unrelased cards. This to me feels odd and unnecessary, particulary now where the cards from SC19 are technically not released although the huge majority of the players already own them.

This PR removes the restriction.