### PR TITLE
Show only latest version of a given card

### DIFF
--- a/web/js/deck.js
+++ b/web/js/deck.js
@@ -103,7 +103,15 @@ Promise.all([NRDB.data.promise, NRDB.settings.promise]).then(function() {
 	function findMatches(q, cb) {
 		if(q.match(/^\w:/)) return;
 		var regexp = new RegExp(q, 'i');
-		cb(NRDB.data.cards.find({title: regexp, pack_code: Filters.pack_code || []}));
+		var matchingCards = NRDB.data.cards.find({title: regexp, pack_code: Filters.pack_code || []});
+		var cardsByName = _.groupBy(matchingCards, card => card.title);
+		var latestCards = Object.keys(cardsByName).map(function (key, index) {
+		    if (cardsByName[key].length === 1) {
+		        return cardsByName[key][0];
+		    }
+		    return _.last(_.sortBy(cardsByName[key], card => card.title));
+		});
+		cb(latestCards);
 	}
 
 	$('#filter-text').typeahead({

--- a/web/js/deck.js
+++ b/web/js/deck.js
@@ -98,27 +98,27 @@ Promise.all([NRDB.data.promise, NRDB.settings.promise]).then(function() {
 	if (Identity.code == "03002") {
 		$('input[name=Jinteki]').prop("checked", false);
 	}
-		
 
 	function findMatches(q, cb) {
 		if(q.match(/^\w:/)) return;
 		var regexp = new RegExp(q, 'i');
+		var latestCardsByTitle = {};
 		var matchingCards = NRDB.data.cards.find({title: regexp, pack_code: Filters.pack_code || []});
-		var cardsByName = _.groupBy(matchingCards, card => card.title);
-		var latestCards = Object.keys(cardsByName).map(function (key, index) {
-		    if (cardsByName[key].length === 1) {
-		        return cardsByName[key][0];
-		    }
-		    return _.last(_.sortBy(cardsByName[key], card => card.title));
-		});
+		for (var card of matchingCards) {
+			var latestCard = latestCardsByTitle[card.title];
+			if (!latestCard || card.code > latestCard.code) {
+				latestCardsByTitle[card.title] = card;
+			}
+		}
+		var latestCards = _.sortBy(latestCardsByTitle, 'title');
 		cb(latestCards);
 	}
 
 	$('#filter-text').typeahead({
-		  hint: true,
-		  highlight: true,
-		  minLength: 2
-		},{
+		hint: true,
+		highlight: true,
+		minLength: 2
+	}, {
 		displayKey: 'title',
 		source: findMatches
 	});


### PR DESCRIPTION
Currently, the deck builder (`https://netrunnerdb.com/en/deck/edit/XX`) search bar shows every instance of a given card in the Typeahead dropdown. This fix changes that it to only show the most recent version of a given card.

Before:
<img width="172" alt="screen shot 2018-12-17 at 10 59 28 am" src="https://user-images.githubusercontent.com/603677/50098919-e8219200-01ea-11e9-82ec-9892744fc028.png">
<img width="283" alt="screen shot 2018-12-18 at 4 44 01 pm" src="https://user-images.githubusercontent.com/603677/50184821-2fd81480-02e4-11e9-8435-5543be314e03.png">


After:
<img width="173" alt="screen shot 2018-12-17 at 10 59 12 am" src="https://user-images.githubusercontent.com/603677/50098905-df30c080-01ea-11e9-8534-c30d0b12a068.png">
<img width="287" alt="screen shot 2018-12-18 at 4 43 42 pm" src="https://user-images.githubusercontent.com/603677/50184827-323a6e80-02e4-11e9-8743-5b35d660594a.png">