### PR TITLE
Select only latest card version in Card Search

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -369,7 +369,9 @@ class SearchController extends Controller
 
         // reconstruction de la bonne chaine de recherche pour affichage
         $q = $cardsData->buildQueryFromConditions($conditions);
-        if ($q && $rows = $cardsData->get_search_rows($conditions, $sort, $locale)) {
+        $rows = $cardsData->get_search_rows($conditions, $sort, $locale);
+        $rows = select_only_latest_cards($rows);
+        if ($q && $rows) {
             if (count($rows) == 1) {
                 $view = 'zoom';
             }
@@ -484,6 +486,21 @@ class SearchController extends Controller
             "metadescription" => $meta,
             "locales"         => $locales,
         ], $response);
+    }
+
+    public function select_only_latest_cards(array $matchingCards)
+    {
+        $latestCardsByTitle = [];
+        foreach ($matchingCards as $card) {
+            $latestCard = null;
+            if (isset($latestCardsByTitle[$card->getTitle()])) {
+                $latestCard = $latestCardsByTitle[$card->getTitle()];
+            }
+            if (!$latestCard || $card->getCode() > $latestCard->getCode()) {
+                $latestCardsByTitle[$card->getTitle()] = $card;
+            }
+        }
+        return array_values($latestCardsByTitle);
     }
 
     /**

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -149,14 +149,27 @@ class CardsData
     {
         $i = 0;
 
-        // construction de la requete sql
-        $qb = $this->entityManager->createQueryBuilder()->from(Card::class, 'c');
-        $qb->select('c', 'p', 'y', 't', 'f', 's');
-        $qb->leftJoin('c.pack', 'p')
+        // Construction of the sql request
+        $init = $this->entityManager->createQueryBuilder();
+        $qb = $init->select('c', 'p', 'y', 't', 'f', 's')
+           ->from(Card::class, 'c')
+           ->leftJoin('c.pack', 'p')
            ->leftJoin('p.cycle', 'y')
            ->leftJoin('c.type', 't')
            ->leftJoin('c.faction', 'f')
-           ->leftJoin('c.side', 's');
+           ->leftJoin('c.side', 's')
+           // Select only the most recent copy of a card
+           ->where(
+               $init->expr()->in(
+                   'c.code',
+                   $this->entityManager->createQueryBuilder()
+                        ->select('MAX(g.code) AS max_code')
+                        ->from(Card::class, 'g')
+                        ->where('g.title = c.title')
+                        ->andWhere('g.max_code = c.code')
+                        ->groupBy('g.title')
+                        ->getDQL()));
+
         $qb2 = null;
         $qb3 = null;
 

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -157,24 +157,14 @@ class CardsData
            ->leftJoin('p.cycle', 'y')
            ->leftJoin('c.type', 't')
            ->leftJoin('c.faction', 'f')
-           ->leftJoin('c.side', 's')
-           // Select only the most recent copy of a card
-           ->where(
-               $init->expr()->in(
-                   'c.code',
-                   $this->entityManager->createQueryBuilder()
-                        ->select('MAX(g.code) AS max_code')
-                        ->from(Card::class, 'g')
-                        ->where('g.title = c.title')
-                        ->andWhere('g.max_code = c.code')
-                        ->groupBy('g.title')
-                        ->getDQL()));
+           ->leftJoin('c.side', 's');
 
         $qb2 = null;
         $qb3 = null;
 
         $clauses = [];
         $parameters = [];
+        $max_code_or = [];
 
         foreach ($conditions as $condition) {
             $type = array_shift($condition);
@@ -188,6 +178,7 @@ class CardsData
                         if ($code) {
                             $or[] = "(c.code = ?$i)";
                             $parameters[$i++] = $arg;
+                            $max_code_or[] = $arg;
                         } elseif ($acronym) {
                             $or[] = "(BINARY(c.title) like ?$i)";
                             $parameters[$i++] = "%$arg%";
@@ -596,6 +587,27 @@ class CardsData
         foreach ($parameters as $index => $parameter) {
             $qb->setParameter($index, $parameter);
         }
+
+        // Select only the most recent copy of a card
+        $mcode = $this->entityManager->createQueryBuilder()
+                      ->select('MAX(g.code) AS max_code')
+                      ->from(Card::class, 'g')
+                      ->where('c.title = g.title')
+                      ->groupBy('g.title');
+        if (!empty($max_code_or)) {
+            $max_code_clauses = [];
+            foreach ($max_code_or as $index => $max_code) {
+                $max_code_clauses[] = "(g.code = ?$index)";
+            }
+            $mcode->andWhere(implode(' or ', $max_code_clauses));
+            foreach ($max_code_or as $index => $max_code) {
+                $mcode->setParameter($index, $max_code);
+            }
+        }
+        $qb->andWhere(
+            $init->expr()->in(
+                'c.code',
+                $mcode->getDQL()));
 
         switch ($sortorder) {
             case 'set':


### PR DESCRIPTION
Currently, the card search (https://netrunnerdb.com/find/?q=XX) shows all copies of a given card in the card list. This fix ~~changes the SQL query that generates that list~~ adds a method to only select the latest copy of a given card.

Before:
<img width="128" alt="screen shot 2018-12-17 at 9 08 53 pm" src="https://user-images.githubusercontent.com/603677/50127983-4ed19a80-0241-11e9-9ff8-f922a4c55e61.png">

After:
<img width="147" alt="screen shot 2018-12-17 at 9 09 06 pm" src="https://user-images.githubusercontent.com/603677/50127981-4aa57d00-0241-11e9-9ab0-62909c8e6852.png">