### PR TITLE
Display other versions on card page

### DIFF
--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -45,7 +45,19 @@
                                         <div class="card-illustrator">
                                             <small>
                                                 {{ card.faction_name }} &bull;
-                                                {% if card.illustrator %}{{ card.illustrator }} &bull; {% endif %}<span class="icon icon-{{ card.cycle_code }}"></span> {{ card.pack_name }} {{ card.position }}
+                                                {% if card.illustrator %}{{ card.illustrator }} &bull; {% endif %}
+                                                <span class="icon icon-{{ card.cycle_code }}"></span>
+                                                {{ card.pack_name }} {{ card.position }}
+                                            </small>
+                                        </div>
+                                        <div class="card-illustrator">
+                                            <small>
+                                                Versions:
+                                                {% for version in card.versions %}
+                                                    <a href="{{ path('cards_zoom',{_locale:app.request.locale,'card_code':version.code}) }}">
+                                                        <span class="icon icon-{{ version.cycle_code }}"> </span>
+                                                    </a>
+                                                {% endfor %}
                                             </small>
                                         </div>
                                     </div>

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -421,13 +421,16 @@ class SearchController extends Controller
                 }
                 $cardinfo['available'] = $availability[$pack->getCode()];
                 if ($view == "zoom") {
-                    $cardinfo['reviews'] = $cardsData->get_reviews($card);
-                    $cardinfo['rulings'] = $cardsData->get_rulings($card);
-                    $cardinfo['mwl_info'] = $cardsData->get_mwl_info($card);
+                    $cardVersions = $versions[$card->getTitle()];
+
                     $cardinfo['versions'] = [];
-                    foreach ($versions[$card->getTitle()] as $version) {
+                    foreach ($cardVersions as $version) {
                         $cardinfo['versions'][] = $cardsData->getCardInfo($version, $locale);
                     }
+
+                    $cardinfo['reviews'] = $cardsData->get_reviews($cardVersions);
+                    $cardinfo['rulings'] = $cardsData->get_rulings($cardVersions);
+                    $cardinfo['mwl_info'] = $cardsData->get_mwl_info($cardVersions);
                 }
                 if ($view == "rulings") {
                     $cardinfo['rulings'] = $cardsData->get_rulings($card);

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -400,6 +400,13 @@ class SearchController extends Controller
             $last = $first + $nb_per_page;
 
             $card = null;
+            $versions = null;
+
+            if ($view == "zoom") {
+                // Other versions of a given card
+                $versions = $cardsData->get_versions();
+            }
+
             // data à passer à la view
             for ($rowindex = $first; $rowindex < $last && $rowindex < count($rows); $rowindex++) {
                 /** @var Card $card */
@@ -417,6 +424,10 @@ class SearchController extends Controller
                     $cardinfo['reviews'] = $cardsData->get_reviews($card);
                     $cardinfo['rulings'] = $cardsData->get_rulings($card);
                     $cardinfo['mwl_info'] = $cardsData->get_mwl_info($card);
+                    $cardinfo['versions'] = [];
+                    foreach ($versions[$card->getTitle()] as $version) {
+                        $cardinfo['versions'][] = $cardsData->getCardInfo($version, $locale);
+                    }
                 }
                 if ($view == "rulings") {
                     $cardinfo['rulings'] = $cardsData->get_rulings($card);

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -911,4 +911,20 @@ class CardsData
 
         return $card;
     }
+
+    /**
+     *  Searches for other versions/releases of all cards
+     *  @return array
+     */
+    public function get_versions()
+    {
+       $cards = $this->entityManager->getRepository(Card::class)->findAll();
+
+        $versions = [];
+        foreach ($cards as $card) {
+            $versions[$card->getTitle()][] = $card;
+        }
+
+        return $versions;
+    }
 }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -811,35 +811,38 @@ class CardsData
         ));
     }
 
-    public function get_mwl_info(Card $card)
+    public function get_mwl_info(array $cards)
     {
         $response = [];
-        $card_code = $card->getCode();
         $mwls = $this->entityManager->getRepository(Mwl::class)->findBy([], ["dateStart" => "DESC"]);
-        foreach ($mwls as $mwl) {
-            $mwl_cards = $mwl->getCards();
-            if (isset($mwl_cards[$card_code])) {
-                $card_mwl = $mwl_cards[$card_code];
-                $is_restricted = $card_mwl['is_restricted'] ?? 0;
-                $deck_limit = $card_mwl['deck_limit'] ?? null;
-                // Ceux-ci signifient la même chose
-                $universal_faction_cost = $card_mwl['universal_faction_cost'] ?? $card_mwl['global_penalty'] ?? 0;
-                $response[] = [
-                    'mwl_name'               => $mwl->getName(),
-                    'active'                 => $mwl->getActive(),
-                    'is_restricted'          => $is_restricted,
-                    'deck_limit'             => $deck_limit,
-                    'universal_faction_cost' => $universal_faction_cost,
-                ];
+
+        foreach ($cards as $card) {
+            $card_code = $card->getCode();
+            foreach ($mwls as $mwl) {
+                $mwl_cards = $mwl->getCards();
+                if (isset($mwl_cards[$card_code])) {
+                    $card_mwl = $mwl_cards[$card_code];
+                    $is_restricted = $card_mwl['is_restricted'] ?? 0;
+                    $deck_limit = $card_mwl['deck_limit'] ?? null;
+                    // Ceux-ci signifient la même chose
+                    $universal_faction_cost = $card_mwl['universal_faction_cost'] ?? $card_mwl['global_penalty'] ?? 0;
+                    $response[] = [
+                        'mwl_name'               => $mwl->getName(),
+                        'active'                 => $mwl->getActive(),
+                        'is_restricted'          => $is_restricted,
+                        'deck_limit'             => $deck_limit,
+                        'universal_faction_cost' => $universal_faction_cost,
+                    ];
+                }
             }
         }
 
         return $response;
     }
 
-    public function get_reviews(Card $card)
+    public function get_reviews(array $cards)
     {
-        $reviews = $this->entityManager->getRepository(Review::class)->findBy(['card' => $card], ['nbvotes' => 'DESC']);
+        $reviews = $this->entityManager->getRepository(Review::class)->findBy(['card' => $cards], ['nbvotes' => 'DESC']);
 
         $response = [];
         $packs = $this->packRepository->findBy([], ["dateRelease" => "ASC"]);
@@ -878,9 +881,9 @@ class CardsData
         return 'Unknown';
     }
 
-    public function get_rulings(Card $card)
+    public function get_rulings(array $cards)
     {
-        $rulings = $this->entityManager->getRepository(Ruling::class)->findBy(['card' => $card], ['dateCreation' => 'ASC']);
+        $rulings = $this->entityManager->getRepository(Ruling::class)->findBy(['card' => $cards], ['dateCreation' => 'ASC']);
 
         $response = [];
         foreach ($rulings as $ruling) {


### PR DESCRIPTION
Currently, cards just display their own information. With this change, a given card page will show the cycle icons for every other version of the same card, by title.

Before:
<img width="344" alt="screen shot 2018-12-18 at 9 11 01 am" src="https://user-images.githubusercontent.com/603677/50159627-254a5a80-02a5-11e9-9caa-a9dd51524b47.png">

After:
<img width="331" alt="screen shot 2018-12-18 at 9 12 49 am" src="https://user-images.githubusercontent.com/603677/50159634-29767800-02a5-11e9-8f2a-4ee5107059f7.png">
