### PR TITLE
Limit faction page to show single version

### DIFF
--- a/src/AppBundle/Controller/DecklistsController.php
+++ b/src/AppBundle/Controller/DecklistsController.php
@@ -27,7 +27,7 @@ class DecklistsController extends Controller
      * @return Response
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function listAction(string $type, int $page = 1, Request $request, EntityManagerInterface $entityManager, DecklistManager $decklistManager)
+    public function listAction(string $type, int $page = 1, Request $request, EntityManagerInterface $entityManager, DecklistManager $decklistManager, CardsData $cardsData)
     {
         $response = new Response();
         $response->setPublic();
@@ -43,7 +43,7 @@ class DecklistsController extends Controller
 
         switch ($type) {
             case 'find':
-                $result = $decklistManager->find($start, $limit, $request);
+                $result = $decklistManager->find($start, $limit, $request, $cardsData);
                 $pagetitle = "Decklist search results";
                 $header = $this->searchForm($request, $entityManager);
                 break;

--- a/src/AppBundle/Controller/FactionController.php
+++ b/src/AppBundle/Controller/FactionController.php
@@ -14,7 +14,7 @@ class FactionController extends Controller
      * @param EntityManagerInterface $entityManager
      * @return Response
      */
-    public function factionAction(string $faction_code, EntityManagerInterface $entityManager)
+    public function factionAction(string $faction_code, EntityManagerInterface $entityManager, CardsData $cardsData)
     {
         $response = new Response();
         $response->setPublic();

--- a/src/AppBundle/Controller/FactionController.php
+++ b/src/AppBundle/Controller/FactionController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Service\CardsData;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,18 +50,27 @@ class FactionController extends Controller
 
             $identities = $qb->getQuery()->getResult();
 
+            $uniqueIdentities = [];
+            foreach ($identities as $card) {
+                $title = $card->getTitle();
+                if (!isset($uniqueIdentities[$title])) {
+                    $uniqueIdentities[$title] = [];
+                }
+                $uniqueIdentities[$title][] = $card;
+            }
+
             $nb_decklists_per_id = 3;
 
             // build the list of the top $nb_decklists_per_id decklists per id
             // also, compute the total points of those decks per id
 
             $decklists = [];
-            foreach ($identities as $identity) {
+            foreach (array_values($uniqueIdentities) as $identities) {
                 $qb = $entityManager->createQueryBuilder();
                 $qb->select('d, (d.nbvotes/(1+DATE_DIFF(CURRENT_TIMESTAMP(),d.dateCreation)/10)) as points')
                    ->from('AppBundle:Decklist', 'd')
-                   ->where('d.identity=:identity')
-                   ->setParameter('identity', $identity)
+                   ->where('d.identity in (:identities)')
+                   ->setParameter('identities', $identities)
                    ->orderBy('points', 'DESC')
                    ->setMaxResults($nb_decklists_per_id);
                 $results = $qb->getQuery()->getResult();
@@ -72,8 +82,10 @@ class FactionController extends Controller
                     $points += intval($row['points']);
                 }
 
+                $identity = $cardsData->select_only_latest_cards($identities);
+
                 $decklists[] = [
-                    'identity'  => $identity,
+                    'identity'  => $identity[0],
                     'points'    => $points,
                     'decklists' => $list,
                 ];

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -370,7 +370,7 @@ class SearchController extends Controller
         // reconstruction de la bonne chaine de recherche pour affichage
         $q = $cardsData->buildQueryFromConditions($conditions);
         $rows = $cardsData->get_search_rows($conditions, $sort, $locale);
-        $rows = $this->select_only_latest_cards($rows);
+        $rows = $cardsData->select_only_latest_cards($rows);
         if ($q && $rows) {
             if (count($rows) == 1) {
                 $view = 'zoom';
@@ -500,21 +500,6 @@ class SearchController extends Controller
             "metadescription" => $meta,
             "locales"         => $locales,
         ], $response);
-    }
-
-    public function select_only_latest_cards(array $matchingCards)
-    {
-        $latestCardsByTitle = [];
-        foreach ($matchingCards as $card) {
-            $latestCard = null;
-            if (isset($latestCardsByTitle[$card->getTitle()])) {
-                $latestCard = $latestCardsByTitle[$card->getTitle()];
-            }
-            if (!$latestCard || $card->getCode() > $latestCard->getCode()) {
-                $latestCardsByTitle[$card->getTitle()] = $card;
-            }
-        }
-        return array_values($latestCardsByTitle);
     }
 
     /**

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -923,7 +923,7 @@ class CardsData
      */
     public function get_versions()
     {
-       $cards = $this->entityManager->getRepository(Card::class)->findAll();
+        $cards = $this->entityManager->getRepository(Card::class)->findAll();
 
         $versions = [];
         foreach ($cards as $card) {
@@ -948,5 +948,24 @@ class CardsData
             }
         }
         return array_values($latestCardsByTitle);
+    }
+
+    public function get_versions_by_code(array $cards_code)
+    {
+        $cards = $this->entityManager->getRepository(Card::class)->findBy(['code' => $cards_code]);
+        $titles = [];
+        foreach ($cards as $card) {
+            $titles[] = $card->getTitle();
+        }
+
+        $qb = $this->entityManager->createQueryBuilder();
+        $qb = $qb->select('c')
+                 ->from(Card::class, 'c')
+                 ->where('c.title in (:titles)')
+                 ->setParameter('titles', $titles);
+        $query = $qb->getQuery();
+        $rows = $query->getResult();
+
+        return $rows;
     }
 }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -932,4 +932,21 @@ class CardsData
 
         return $versions;
     }
+
+    public function select_only_latest_cards(array $matchingCards)
+    {
+        $latestCardsByTitle = [];
+        foreach ($matchingCards as $card) {
+            $latestCard = null;
+            $title = $card->getTitle();
+
+            if (isset($latestCardsByTitle[$title])) {
+                $latestCard = $latestCardsByTitle[$title];
+            }
+            if (!$latestCard || $card->getCode() > $latestCard->getCode()) {
+                $latestCardsByTitle[$title] = $card;
+            }
+        }
+        return array_values($latestCardsByTitle);
+    }
 }


### PR DESCRIPTION
Faction page currently shows multiple versions of a given Identity. This limits that to a single version.

Decklist Search now searches for all versions of a selected/given card, regardless of how many cards are selected. Also about 10x faster than the previous version of the SQL query.