### PR TITLE
change authentication requirement from FULLY to REMEMBERED

### DIFF
--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -595,7 +595,7 @@ class BuilderController extends Controller
      * @param EntityManagerInterface $entityManager
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      *
-     * @IsGranted("IS_AUTHENTICATED_FULLY")
+     * @IsGranted("IS_AUTHENTICATED_REMEMBERED")
      */
     public function deleteAction(Request $request, EntityManagerInterface $entityManager)
     {
@@ -624,7 +624,7 @@ class BuilderController extends Controller
      * @param EntityManagerInterface $entityManager
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      *
-     * @IsGranted("IS_AUTHENTICATED_FULLY")
+     * @IsGranted("IS_AUTHENTICATED_REMEMBERED")
      */
     public function deleteListAction(Request $request, EntityManagerInterface $entityManager)
     {

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -38,7 +38,7 @@ class DefaultController extends Controller
      * @param EntityManagerInterface $entityManager
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
      *
-     * @IsGranted("IS_AUTHENTICATED_FULLY")
+     * @IsGranted("IS_AUTHENTICATED_REMEMBERED")
      */
     public function saveProfileAction(Request $request, EntityManagerInterface $entityManager)
     {

--- a/src/AppBundle/Controller/ReviewController.php
+++ b/src/AppBundle/Controller/ReviewController.php
@@ -25,7 +25,7 @@ class ReviewController extends Controller
      * @param TextProcessor          $textProcessor
      * @return Response
      *
-     * @IsGranted("IS_AUTHENTICATED_FULLY")
+     * @IsGranted("IS_AUTHENTICATED_REMEMBERED")
      */
     public function postAction(Request $request, EntityManagerInterface $entityManager, TextProcessor $textProcessor)
     {
@@ -88,7 +88,7 @@ class ReviewController extends Controller
      * @param TextProcessor          $textProcessor
      * @return Response
      *
-     * @IsGranted("IS_AUTHENTICATED_FULLY")
+     * @IsGranted("IS_AUTHENTICATED_REMEMBERED")
      */
     public function editAction(Request $request, EntityManagerInterface $entityManager, TextProcessor $textProcessor)
     {


### PR DESCRIPTION
This should fix the bad UX shown in #247, #250 and #252.

I didn't change the annotation for `saveDeckAction` in `PrivateApi20Controller.php` because a) I have no idea how to test private API access locally, and b) I have never experienced a problem using this API from Net Deck.