### PR TITLE
LegalityApplyMwlCommand Optimization

### DIFF
--- a/src/AppBundle/Command/LegalityApplyMwlCommand.php
+++ b/src/AppBundle/Command/LegalityApplyMwlCommand.php
@@ -109,15 +109,13 @@ class LegalityApplyMwlCommand extends ContainerAwareCommand
         $fetchQuery = $this->entityManager->createQuery($fetchDql)->setParameter(1, $mwl);
         $iterableResult = $fetchQuery->iterate();
         foreach ($iterableResult as $row) {
-            $mwls = $this->entityManager->getRepository('AppBundle:Mwl')->findAll();
+            $mwl = $this->entityManager->getRepository('AppBundle:Mwl')->findOneBy(['code' => $mwl_code]);
 
-            foreach ($mwls as $m) {
-                $legality = new Legality();
-                $legality->setDecklist($row[0]);
-                $legality->setMwl($m);
-                $this->judge->computeLegality($legality);
-                $this->entityManager->persist($legality);
-            }
+            $legality = new Legality();
+            $legality->setDecklist($row[0]);
+            $legality->setMwl($mwl);
+            $this->judge->computeLegality($legality);
+            $this->entityManager->persist($legality);
 
             if (($i % $batchSize) === 0) {
                 $this->entityManager->flush();

--- a/src/AppBundle/Command/LegalityDecklistsRotationCommand.php
+++ b/src/AppBundle/Command/LegalityDecklistsRotationCommand.php
@@ -32,23 +32,23 @@ class LegalityDecklistsRotationCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $sql = "UPDATE decklist d"
-            . "JOIN decklistslot s ON d.id = s.decklist_id"
-            . "JOIN card c ON s.card_id = c.id"
-            . "JOIN pack p ON c.pack_id = p.id"
-            . "JOIN cycle y ON p.cycle_id = y.id"
-            . "SET d.is_legal = 1"
-            . "WHERE d.is_legal = 0"
-            . "AND y.rotated = 1"
-            . "AND EXISTS ("
-            . "    SELECT *"
-            . "    FROM card nc"
-            . "    JOIN pack np ON nc.pack_id = np.id"
-            . "    JOIN cycle ny ON np.cycle_id = ny.id"
-            . "    WHERE nc.id <> c.id"
-            . "    AND nc.title = c.title"
-            . "    AND np.id >= p.id"
-            . "    AND ny.rotated = 0);";
+        $sql = "UPDATE decklist d
+            JOIN decklistslot s ON d.id = s.decklist_id
+            JOIN card c ON s.card_id = c.id
+            JOIN pack p ON c.pack_id = p.id
+            JOIN cycle y ON p.cycle_id = y.id
+            SET d.is_legal = 1
+            WHERE d.is_legal = 0
+            AND y.rotated = 1
+            AND EXISTS (
+                SELECT *
+                FROM card nc
+                JOIN pack np ON nc.pack_id = np.id
+                JOIN cycle ny ON np.cycle_id = ny.id
+                WHERE nc.id <> c.id
+                AND nc.title = c.title
+                AND np.id >= p.id
+                AND ny.rotated = 0);";
 
         $this->entityManager->getConnection()->executeQuery($sql);
 

--- a/src/AppBundle/Command/LegalityDecklistsRotationCommand.php
+++ b/src/AppBundle/Command/LegalityDecklistsRotationCommand.php
@@ -32,15 +32,24 @@ class LegalityDecklistsRotationCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $sql = "UPDATE decklist d SET d.is_legal=0 WHERE d.is_legal=1"
-                . " AND EXISTS(SELECT *"
-                . " FROM decklistslot s"
-                . " JOIN card c ON c.id=s.card_id"
-                . " JOIN pack p ON p.id=c.pack_id"
-                . " JOIN cycle y ON y.id=p.cycle_id"
-                . " WHERE y.rotated=1"
-                . " AND d.id=s.decklist_id)";
-        
+        $sql = "UPDATE decklist d"
+            . "JOIN decklistslot s ON d.id = s.decklist_id"
+            . "JOIN card c ON s.card_id = c.id"
+            . "JOIN pack p ON c.pack_id = p.id"
+            . "JOIN cycle y ON p.cycle_id = y.id"
+            . "SET d.is_legal = 1"
+            . "WHERE d.is_legal = 0"
+            . "AND y.rotated = 1"
+            . "AND EXISTS ("
+            . "    SELECT *"
+            . "    FROM card nc"
+            . "    JOIN pack np ON nc.pack_id = np.id"
+            . "    JOIN cycle ny ON np.cycle_id = ny.id"
+            . "    WHERE nc.id <> c.id"
+            . "    AND nc.title = c.title"
+            . "    AND np.id >= p.id"
+            . "    AND ny.rotated = 0);";
+
         $this->entityManager->getConnection()->executeQuery($sql);
 
         $output->writeln("<info>Done</info>");


### PR DESCRIPTION
This is only meant to be run when a new MWL is released, so as to add the required Legality entries into the db. It previously took multiple hours, because it would perform the extremely costly `detach`, `flush`, and `clear` calls after every row, and it would fetch the entire list every iteration, working only on the next one.

This PR converts the entire process into a `iterate`able Doctrine query, which allows for easily stepping through all of the rows and only flushing to the DB every so often. This greatly reduces the workload on the server.