### PR TITLE
Ignore diacritics in typeahead

### DIFF
--- a/web/js/deck.js
+++ b/web/js/deck.js
@@ -101,7 +101,7 @@ Promise.all([NRDB.data.promise, NRDB.settings.promise]).then(function() {
 	function findMatches(q, cb) {
 		if(q.match(/^\w:/)) return;
 		var regexp = new RegExp(q, 'i');
-		var matchingCards = NRDB.data.cards.find({title: regexp, pack_code: Filters.pack_code || []});
+		var matchingCards = NRDB.data.cards.find({normalized_title: regexp, pack_code: Filters.pack_code || []});
 		var latestCards = select_only_latest_cards(matchingCards);
 		cb(latestCards);
 	}

--- a/web/js/nrdb.data.js
+++ b/web/js/nrdb.data.js
@@ -93,6 +93,7 @@
                                 if (dbName === 'cards') {
                                     response.data.forEach(function (card) {
                                       card.imageUrl = card.image_url || response.imageUrlTemplate.replace(/{code}/, card.code);
+                                      card.normalized_title = card.normalize('NFD').replace(/[^\x00-\x7F]+/, '').toLowerCase().trim();
                                     });
                                 }
 

--- a/web/js/search.js
+++ b/web/js/search.js
@@ -2,7 +2,7 @@ $(document).on('data.app', function() {
 	function findMatches(q, cb) {
 		if(q.match(/^\w:/)) return;
 		var regexp = new RegExp(q, 'i');
-		var matchingCards = NRDB.data.cards.find({title: regexp});
+		var matchingCards = NRDB.data.cards.find({normalized_title: regexp});
 		var latestCards = select_only_latest_cards(matchingCards);
 		cb(latestCards);
 	}


### PR DESCRIPTION
Should fix the problem of searching for "Şifr" when deckbuilding that doesn't exist in the header card search.

Fixes #47 
Fixes #83 
Fixes #129 