### PR TITLE
Add a field for patreon pledges

### DIFF
--- a/src/AppBundle/Command/DonatorCommand.php
+++ b/src/AppBundle/Command/DonatorCommand.php
@@ -60,7 +60,7 @@ class DonatorCommand extends ContainerAwareCommand
                 if ($type == 'paypal') {
                     $user->setDonation($amount + $user->getDonation());
                 } else {
-                    $user->setPledgeCents($amount * 100);
+                    $user->setPatreonPledgeCents($amount * 100);
                 }
                 $this->entityManager->flush();
                 $output->writeln(date('c') . " " . "Success");
@@ -68,7 +68,7 @@ class DonatorCommand extends ContainerAwareCommand
                 $output->writeln(date('c') . " " . "Cannot find user [$email]");
             }
         } else {
-            $output->writeln(date('c') . " " . "Invalid donation type");
+            $output->writeln(date('c') . " " . "Invalid donation type [$type]: expected 'patreon' or 'paypal'");
         }
     }
 }

--- a/src/AppBundle/Command/DonatorCommand.php
+++ b/src/AppBundle/Command/DonatorCommand.php
@@ -31,16 +31,22 @@ class DonatorCommand extends ContainerAwareCommand
                 'Email address or username of user'
             )
             ->addArgument(
-                'donation',
+                'type',
                 InputArgument::REQUIRED,
-                'Amount of donation'
+                '"paypal" or "patreon"'
+            )
+            ->addArgument(
+                'amount',
+                InputArgument::REQUIRED,
+                'Amount of donation in US dollars'
             );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $email = $input->getArgument('email');
-        $donation = $input->getArgument('donation');
+        $type = $input->getArgument('type');
+        $amount = $input->getArgument('amount');
 
         $repo = $this->entityManager->getRepository('AppBundle:User');
         /** @var User $user */
@@ -49,12 +55,20 @@ class DonatorCommand extends ContainerAwareCommand
             $user = $repo->findOneBy(['username' => $email]);
         }
 
-        if ($user instanceof User) {
-            $user->setDonation($donation + $user->getDonation());
-            $this->entityManager->flush();
-            $output->writeln(date('c') . " " . "Success");
+        if ($type == 'patreon' or $type == 'paypal') {
+            if ($user instanceof User) {
+                if ($type == 'paypal') {
+                    $user->setDonation($amount + $user->getDonation());
+                } else {
+                    $user->setPledgeCents($amount * 100);
+                }
+                $this->entityManager->flush();
+                $output->writeln(date('c') . " " . "Success");
+            } else {
+                $output->writeln(date('c') . " " . "Cannot find user [$email]");
+            }
         } else {
-            $output->writeln(date('c') . " " . "Cannot find user [$email]");
+            $output->writeln(date('c') . " " . "Invalid donation type");
         }
     }
 }

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -52,6 +52,8 @@ class User extends BaseUser
     
     private $donation;
 
+    private $patreon_pledge_cents;
+
     /**
      * @var Collection|Deck[]
      */
@@ -161,6 +163,7 @@ class User extends BaseUser
         $this->faction = 'neutral-runner';
         $this->creation = new \DateTime();
         $this->donation = 0;
+        $this->patreon_pledge_cents = 0;
 
         parent::__construct();
     }
@@ -298,6 +301,33 @@ class User extends BaseUser
         return $this;
     }
     
+    /**
+     * @return integer
+     */
+    public function getPledgeCents()
+    {
+        return $this->patreon_pledge_cents;
+    }
+
+    /**
+     * @param integer $pledge_cents
+     * @return User
+     */
+    public function setPledgeCents(int $pledge_cents)
+    {
+        $this->patreon_pledge_cents = $pledge_cents;
+
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isSupporter()
+    {
+        return ($this->donation > 0 || $this->patreon_pledge_cents > 0);
+    }
+
     /**
      * @return Deck[]|Collection
      */

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -304,7 +304,7 @@ class User extends BaseUser
     /**
      * @return integer
      */
-    public function getPledgeCents()
+    public function getPatreonPledgeCents()
     {
         return $this->patreon_pledge_cents;
     }
@@ -313,7 +313,7 @@ class User extends BaseUser
      * @param integer $pledge_cents
      * @return User
      */
-    public function setPledgeCents(int $pledge_cents)
+    public function setPatreonPledgeCents(int $pledge_cents)
     {
         $this->patreon_pledge_cents = $pledge_cents;
 

--- a/src/AppBundle/Resources/config/doctrine/User.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/User.orm.yml
@@ -75,6 +75,11 @@ AppBundle\Entity\User:
         donation:
             type: integer
             nullable: false
+        patreon_pledge_cents:
+            type: integer
+            nullable: false
+            options:
+                default: 0
         notif_author:
             type: boolean
             nullable: false

--- a/src/AppBundle/Service/PersonalizationHelper.php
+++ b/src/AppBundle/Service/PersonalizationHelper.php
@@ -47,7 +47,7 @@ class PersonalizationHelper
             'introductions'      => $user->getIntroductions(),
             'faction'            => $user->getFaction(),
             'autoload_images'    => $user->getAutoloadImages(),
-            'donation'           => $user->getDonation(),
+            'is_supporter'       => $user->isSupporter(),
             'unchecked_activity' => $this->activityHelper->countUncheckedItems($this->activityHelper->getItems($user)),
             'is_moderator'       => $this->authorizationChecker->isGranted('ROLE_MODERATOR'),
             'roles'              => $user->getRoles(),

--- a/web/js/nrdb.user.js
+++ b/web/js/nrdb.user.js
@@ -46,7 +46,7 @@
     
     user.always = function () {
         // show ads if not donator
-        if(user.data && user.data.donation > 0) {
+        if(user.data && user.data.is_supporter) {
             // thank you!
         } else {
             user.showAds();


### PR DESCRIPTION
An attempt to handle Patreon pledges while leaving the current donation info untouched.

Requires a schema update. Output of `php bin/console doctrine:schema:update --dump-sql` is:

>     ALTER TABLE user ADD patreon_pledge_cents INT DEFAULT 0 NOT NULL;

So if we do use this, that needs to be run on production before the code there is updated, I guess? I'm still not 100% clear on how Symfony's schema management works.