### PR TITLE
Update select_only_latest_cards to preserve card order

### DIFF
--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -952,11 +952,9 @@ class CardsData
             }
         }
 
-        $cardFilter = function ($card, $key) use ($latestCardsByTitle) {
+        return array_values(array_filter($matchingCards, function ($card) use ($latestCardsByTitle) {
             return $card->getCode() == $latestCardsByTitle[$card->getTitle()]->getCode();
-        };
-
-        return array_values(array_filter($matchingCards, 'cardFilter'));
+        }));
     }
 
     public function get_versions_by_code(array $cards_code)

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -951,7 +951,12 @@ class CardsData
                 $latestCardsByTitle[$title] = $card;
             }
         }
-        return array_values($latestCardsByTitle);
+
+        $cardFilter = function ($card, $key) use ($latestCardsByTitle) {
+            return $card->getCode() == $latestCardsByTitle[$card->getTitle()]->getCode();
+        };
+
+        return array_values(array_filter($matchingCards, 'cardFilter'));
     }
 
     public function get_versions_by_code(array $cards_code)

--- a/web/js/search.js
+++ b/web/js/search.js
@@ -6,7 +6,7 @@ $(document).on('data.app', function() {
 		var matchingCards = _.filter(latestCards, function (card) {
 			return regexp.test(_.deburr(card.title).toLowerCase().trim());
 		});
-		cb(matchingCards);
+		cb(_.sortBy(matchingCards, 'title'));
 	}
 
 	$('#filter-text').typeahead({
@@ -28,7 +28,9 @@ function select_only_latest_cards(matchingCards) {
 			latestCardsByTitle[card.title] = card;
 		}
 	}
-	return _.sortBy(latestCardsByTitle, 'title');
+	return matchingCards.filter(function(value, index, arr) {
+		return value.code == latestCardsByTitle[value.title].code;
+	});
 }
 
 function handle_checkbox_change() {


### PR DESCRIPTION
Updates other uses of `select_only_latest_cards` to match @plural's fixes.