### PR TITLE
Refactor Search Options

### DIFF
--- a/app/Resources/views/Search/searchoptions.html.twig
+++ b/app/Resources/views/Search/searchoptions.html.twig
@@ -1,15 +1,6 @@
-{% set sort_options = {
-	'name': 'Name',
-	'set': 'Set Name',
-	'release-date': 'Release Date',
-	'faction': 'Faction',
-	'type': 'Type',
-	'cost': 'Cost',
-	'strength': 'Strength',
-} %}
 <div class="col-sm-4" style="margin-bottom:.5em">
 	<select name="sort" class="form-control">
-		{% for key, value in sort_options|cast_to_array %}
+		{% for key, value in sort_options %}
 			<option value={{key}} {% if sort == key %}selected{% endif %}>
 			Sort by {{value}}
 			</option>
@@ -17,16 +8,9 @@
 	</select>
 </div>
 
-{% set view_options = {
-	'list': 'a Checklist',
-	'text': 'a Spoiler',
-	'full': 'Full Cards',
-	'images': 'Images only',
-	'short': 'Names only',
-} %}
 <div class="col-sm-4" style="margin-bottom:.5em">
 	<select name="view" class="form-control">
-		{% for key, value in view_options|cast_to_array %}
+		{% for key, value in view_options %}
 			<option value={{key}} {% if view == key %}selected{% endif %}>
 			View as {{value}}
 			</option>

--- a/app/Resources/views/Search/searchoptions.html.twig
+++ b/app/Resources/views/Search/searchoptions.html.twig
@@ -1,21 +1,39 @@
+{% set sort_options = {
+	'name': 'Name',
+	'set': 'Set Name',
+	'release-date': 'Release Date',
+	'faction': 'Faction',
+	'type': 'Type',
+	'cost': 'Cost',
+	'strength': 'Strength',
+} %}
 <div class="col-sm-4" style="margin-bottom:.5em">
-<select name="sort" class="form-control">
-	<option value="name"    {% if sort|default('name') == "name"    %}selected{% endif %}>Sort by Name</option>
-	<option value="set"     {% if sort|default('name') == "set"     %}selected{% endif %}>Sort by Set</option>
-	<option value="faction" {% if sort|default('name') == "faction" %}selected{% endif %}>Sort by Faction</option>
-	<option value="type"    {% if sort|default('name') == "type"    %}selected{% endif %}>Sort by Type</option>
-	<option value="cost"    {% if sort|default('name') == "cost"    %}selected{% endif %}>Sort by Cost</option>
-	<option value="strength"{% if sort|default('name') == "strength"%}selected{% endif %}>Sort by Strength</option>
-</select>
+	<select name="sort" class="form-control">
+		{% for key, value in sort_options|cast_to_array %}
+			<option value={{key}} {% if sort == key %}selected{% endif %}>
+			Sort by {{value}}
+			</option>
+		{% endfor %}
+	</select>
 </div>
+
+{% set view_options = {
+	'list': 'Checklist',
+	'text': 'Spoiler',
+	'full': 'Full Cards',
+	'images': 'Scans',
+	'short': 'Names',
+} %}
 <div class="col-sm-4" style="margin-bottom:.5em">
-<select name="view" class="form-control">
-	<option value="list"    {% if view|default('list') == "list"    %}selected{% endif %}>View as a Checklist</option>
-	<option value="text"    {% if view|default('list') == "text" %}selected{% endif %}>View as a Spoiler</option>
-	<option value="full"    {% if view|default('list') == "full"    %}selected{% endif %}>View as Full Cards</option>
-	<option value="images"  {% if view|default('list') == "images"    %}selected{% endif %}>View as Scans only</option>
-        <option value="rulings"  {% if view|default('list') == "rulings"    %}selected{% endif %}>View Rulings</option>
-	<option value="short"   {% if view|default('list') == "short"   %}selected{% endif %}>View as Simple List</option>
-</select>
-<input name="_locale" type="hidden" value="{{ app.request.locale }}">
+	<select name="view" class="form-control">
+		{% for key, value in view_options|cast_to_array %}
+			<option value={{key}} {% if view == key %}selected{% endif %}>
+			Display as {{value}}
+			</option>
+		{% endfor %}
+	</select>
+</div>
+
+<div>
+	<input name="_locale" type="hidden" value="{{ app.request.locale }}">
 </div>

--- a/app/Resources/views/Search/searchoptions.html.twig
+++ b/app/Resources/views/Search/searchoptions.html.twig
@@ -18,17 +18,17 @@
 </div>
 
 {% set view_options = {
-	'list': 'Checklist',
-	'text': 'Spoiler',
+	'list': 'a Checklist',
+	'text': 'a Spoiler',
 	'full': 'Full Cards',
-	'images': 'Scans',
-	'short': 'Names',
+	'images': 'Images only',
+	'short': 'Names only',
 } %}
 <div class="col-sm-4" style="margin-bottom:.5em">
 	<select name="view" class="form-control">
 		{% for key, value in view_options|cast_to_array %}
 			<option value={{key}} {% if view == key %}selected{% endif %}>
-			Display as {{value}}
+			View as {{value}}
 			</option>
 		{% endfor %}
 	</select>

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -14,6 +14,23 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SearchController extends Controller
 {
+    const SORT_OPTIONS = array(
+        'name'         => 'Name',
+        'set'          => 'Set Name',
+        'release-date' => 'Release Date',
+        'faction'      => 'Faction',
+        'type'         => 'Type',
+        'cost'         => 'Cost',
+        'strength'     => 'Strength'
+    );
+
+    const VIEW_OPTIONS = array(
+        'list'   => 'a Checklist',
+        'text'   => 'a Spoiler',
+        'full'   => 'Full Cards',
+        'images' => 'Images only',
+        'short'  => 'Names only'
+    );
     /**
      * @param EntityManagerInterface $entityManager
      * @param CardsData              $cardsData
@@ -84,6 +101,10 @@ class SearchController extends Controller
             "types"           => $types,
             "keywords"        => $keywords,
             "illustrators"    => $illustrators,
+            "sort"            => "name",
+            "view"            => "list",
+            "sort_options"    => self::SORT_OPTIONS,
+            "view_options"    => self::VIEW_OPTIONS,
         ], $response);
     }
 
@@ -468,9 +489,11 @@ class SearchController extends Controller
         }
 
         $searchbar = $this->renderView('/Search/searchbar.html.twig', [
-            "q"    => $q,
-            "view" => $view,
-            "sort" => $sort,
+            "q"            => $q,
+            "view"         => $view,
+            "sort"         => $sort,
+            "sort_options" => self::SORT_OPTIONS,
+            "view_options" => self::VIEW_OPTIONS,
         ]);
 
         if (empty($title)) {

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -592,7 +592,7 @@ class CardsData
 
         switch ($sortorder) {
             case 'set':
-                $qb->orderBy('y.code')->addOrderBy('c.position');
+                $qb->orderBy('p.name')->addOrderBy('c.position');
                 break;
             case 'name':
                 $qb->orderBy('c.title');

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -591,11 +591,14 @@ class CardsData
         }
 
         switch ($sortorder) {
+            case 'name':
+                $qb->orderBy('c.title');
+                break;
             case 'set':
                 $qb->orderBy('p.name')->addOrderBy('c.position');
                 break;
-            case 'name':
-                $qb->orderBy('c.title');
+            case 'release-date':
+                $qb->orderBy('y.position')->addOrderBy('p.position')->addOrderBy('c.position');
                 break;
             case 'faction':
                 $qb->orderBy('c.side', 'DESC')->addOrderBy('c.faction')->addOrderBy('c.type');

--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -1,0 +1,21 @@
+<?php
+namespace AppBundle\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class AppExtension extends AbstractExtension
+{
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('cast_to_array', [$this, 'objectFilter']),
+        ];
+    }
+
+    public function objectFilter($stdClassObject) {
+        $response = (array)$stdClassObject;
+
+        return $response;
+    }
+}

--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -6,16 +6,4 @@ use Twig\TwigFilter;
 
 class AppExtension extends AbstractExtension
 {
-    public function getFilters()
-    {
-        return [
-            new TwigFilter('cast_to_array', [$this, 'objectFilter']),
-        ];
-    }
-
-    public function objectFilter($stdClassObject) {
-        $response = (array)$stdClassObject;
-
-        return $response;
-    }
 }


### PR DESCRIPTION
Currently, the two search option lists have problems. "Sort by Set" is ambiguous: is it by release date or by set name? And View Rulings is broken. Additionally, the searchoptions twig is ugly as sin and hard to work with.

This refactors the entire file, making it more consistent and easier to manage. I changed "Sort by Set" to unambiguously be "Sort by Set Name" and added a "Sort by Release Date" option. I also removed the "View Rulings" option as it's out of scope for this PR to fix and it's bad to leave broken options available for use and changed "Simple List" to be "Names only", which is more accurate and clear.

I also made both lists somewhat consistent in their language: "Sort by {{blank}}" and "View as {{blank}}".

### Before:
Sort: 
![screen shot 2019-03-05 at 10 44 42 am](https://user-images.githubusercontent.com/603677/53817597-cefbc800-3f33-11e9-8728-175e609830cf.png)
View:
![screen shot 2019-03-05 at 10 44 46 am](https://user-images.githubusercontent.com/603677/53817620-d8853000-3f33-11e9-9152-e13ec86962d4.png)

### After
Sort:
![screen shot 2019-03-05 at 10 45 02 am](https://user-images.githubusercontent.com/603677/53817627-de7b1100-3f33-11e9-856c-512aa785e254.png)
View:
![image](https://user-images.githubusercontent.com/603677/53817782-5a755900-3f34-11e9-86c7-03cae30a977b.png)
