### PR TITLE
Firefox: Show card thumbnails when hovering over a card

### DIFF
--- a/web/js/nrdb.tip.js
+++ b/web/js/nrdb.tip.js
@@ -31,8 +31,7 @@
         if(card.strength != null)
             type += '<p>Strength <b>' + card.strength + '</b></p>';
         var image_svg = '';
-        if($('#nrdb_svg_hex').length && typeof InstallTrigger === 'undefined') {
-            // no hexagon for Firefox, bad boy!
+        if($('#nrdb_svg_hex').length) {
             image_svg = '<div class="card-image card-image-' + card.side_code + '-' + card.type_code + '"' + (card.imageUrl ? ' style="background-image:url(' + card.imageUrl + ')"' : '')
                     + '><svg width="103px" height="90px" viewBox="0 0 677 601" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><mask id="mask"><use xlink:href="#rect" style="fill:white" /><use xlink:href="#hex" style="fill:black"/></mask><use xlink:href="#rect" mask="url(#mask)"/><use xlink:href="#hex" style="stroke:black;fill:none;stroke-width:15" /></svg></div>';
         }


### PR DESCRIPTION
As far as I can tell, there is no longer any reason to not display these nice thumbnails in Firefox.

fixes #161