### PR TITLE
Sort for the previous and next cards by position on the card nav.

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -511,7 +511,6 @@ class SearchController extends Controller
      */
     public function setnavigation(Card $card, string $locale, EntityManagerInterface $entityManager)
     {
-        // $jason_prev = $card->findPriorCardByPosition($card->getPack(), $card->getPosition());
         $em = $entityManager->getRepository('AppBundle:Card');
         $prev = $em->createQueryBuilder('c')
             ->andWhere('c.pack = :pack')

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -511,8 +511,26 @@ class SearchController extends Controller
      */
     public function setnavigation(Card $card, string $locale, EntityManagerInterface $entityManager)
     {
-        $prev = $entityManager->getRepository('AppBundle:Card')->findOneBy(["pack" => $card->getPack(), "position" => $card->getPosition() - 1]);
-        $next = $entityManager->getRepository('AppBundle:Card')->findOneBy(["pack" => $card->getPack(), "position" => $card->getPosition() + 1]);
+        // $jason_prev = $card->findPriorCardByPosition($card->getPack(), $card->getPosition());
+        $em = $entityManager->getRepository('AppBundle:Card');
+        $prev = $em->createQueryBuilder('c')
+            ->andWhere('c.pack = :pack')
+            ->andWhere('c.position < :position')
+            ->setParameter('pack', $card->getPack())
+            ->setParameter('position', $card->getPosition())
+            ->orderBy('c.position', 'DESC')
+            ->getQuery()
+            ->setMaxResults(1)
+            ->getOneOrNullResult();
+        $next = $em->createQueryBuilder('c')
+            ->andWhere('c.pack = :pack')
+            ->andWhere('c.position > :position')
+            ->setParameter('pack', $card->getPack())
+            ->setParameter('position', $card->getPosition())
+            ->orderBy('c.position', 'ASC')
+            ->getQuery()
+            ->setMaxResults(1)
+            ->getOneOrNullResult();
 
         return $this->renderView('/Search/setnavigation.html.twig', [
             "prevtitle" => $prev instanceof Card ? $prev->getTitle() : "",


### PR DESCRIPTION
This fixes the issue that assumes sets are complete and fixes the navigation for things like slowly-spoiled sets like Downfall.  :)

Fixes #326 