### PR TITLE
Clean up and make consistent "Text file" export actions

### DIFF
--- a/src/AppBundle/Service/DeckManager.php
+++ b/src/AppBundle/Service/DeckManager.php
@@ -147,7 +147,7 @@ class DeckManager
 
             $problem_message = '';
             if (isset($deck['problem'])) {
-                $problem_message = $this->judge->problem($deck['problem']);
+                $problem_message = $this->judge->problem($deck);
             }
             if ($decks[$i]['unsaved'] > 0) {
                 $problem_message = "This deck has unsaved changes.";
@@ -376,8 +376,8 @@ class DeckManager
             ];
         }
         $analyse = $this->judge->analyse($deck->getSlots()->toArray());
-        if (is_string($analyse)) {
-            $deck->setProblem($analyse);
+        if (isset($analyse['problem'])) {
+            $deck->setProblem($analyse['problem']);
         } else {
             $deck->setProblem(null);
             $deck->setDeckSize($analyse['deckSize']);


### PR DESCRIPTION
Currently, the "Text file" download action is different for private and public decks. Additionally, because the private deck action relies on the deck getters to relay information, and that isn't re-calculated when the saved deck is illegal, the export will print the correct card lists but print incorrect deck information (size, agenda points, etc).

This cleans up and unifies both. Sadly, I'm not confident enough in my PHP to know if I can pull this out into a helper (CardsData or another), but I welcome all suggestions.

Closes an issue raised on stimslack, lol.