### PR TITLE
Fix searching for X/null cost and strength values

### DIFF
--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -360,10 +360,10 @@ class CardsData
                 case 'o': // cost
                     $or = [];
                     foreach ($condition as $arg) {
-                        if ($arg === 'X') {
+                        if (($arg === 'x') or ($arg === 'X')) {
                             switch ($operator) {
                                 case ':':
-                                    $or[] = "(c.cost is null)";
+                                    $or[] = "(c.cost is null and (t.code not in ('agenda', 'identity')))";
                                     break;
                                 case '!':
                                     $or[] = "(c.cost is not null)";
@@ -455,10 +455,15 @@ class CardsData
                 case 'p': // strength
                     $or = [];
                     foreach ($condition as $arg) {
-                        if ($arg === 'X') {
+                        if (($arg === 'x') or ($arg === 'X')) {
                             switch ($operator) {
                                 case ':':
-                                    $or[] = "(c.strength is null)";
+                                    $or[] = "(c.strength is null and ((t.code = 'ice') or ((c.keywords = ?$i) or (c.keywords like ?" . ($i + 1) . ") or (c.keywords like ?" . ($i + 2) . ") or (c.keywords like ?" . ($i + 3) . "))))";
+                                    $ib = "Icebreaker";
+                                    $parameters[$i++] = "$ib";
+                                    $parameters[$i++] = "$ib %";
+                                    $parameters[$i++] = "% $ib";
+                                    $parameters[$i++] = "% $ib %";
                                     break;
                                 case '!':
                                     $or[] = "(c.strength is not null)";
@@ -670,8 +675,10 @@ class CardsData
             $cardinfo['cost'] = 'X';
         }
 
-        // setting the card strength to X if the strength is null and the card subtype has icebreaker
-        if ($cardinfo['strength'] === null && strstr($cardinfo['subtype'], 'Icebreaker') !== false) {
+        // setting the card strength to X if the strength is null and the card is ICE or Program - Icebreaker
+        if ($cardinfo['strength'] === null &&
+            ($cardinfo['type_code'] === 'ice' ||
+             strstr($cardinfo['subtype'], 'Icebreaker') !== false)) {
             $cardinfo['strength'] = 'X';
         }
 


### PR DESCRIPTION
It's kinda messed up as you can search `o:X` or `p:X` for `NULL` cost or strength but it'll return _all_ cards with null values, so you have to specify icebreaker/ice or non-agenda/non-identity, etc. Very annoying. Seeing as you'd never want to search for a null value by itself, this seems like the smartest fix.