### PR TITLE
Fixed the search bar width issue, but don't understand how

### DIFF
--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -138,9 +138,7 @@ var Filters = {},
 		<!-- Search Bar -->
 		<div class="row">
 			<div class="col-sm-12" style="margin-bottom:10px">
-				<div class="input-group">
-					<input type="text" class="form-control input-sm" id="filter-text" placeholder="Find a card or filter the list" tabindex="1">
-				</div>
+				<input type="text" class="form-control input-sm" id="filter-text" placeholder="Find a card or filter the list" tabindex="1">
 			</div>
 		</div>
 		<!-- Search Bar -->


### PR DESCRIPTION
Currently, the search bar in the deckbuilder is mad narrow:

![image](https://user-images.githubusercontent.com/10621139/54789897-1371ae00-4c2c-11e9-9a82-3289cf8c74cb.png)

which makes the UI look a bit ugly and dropdown options even worse:

![image](https://user-images.githubusercontent.com/10621139/54789926-2b493200-4c2c-11e9-84b0-8e20e19e498f.png)

This PR fixes that, but I suspect not in the "right" way, as my CSS skills leave a lot to be desired. So I could see that it was the div wrapping the input field with the `input-group` class that appeared to be restricting the width of that object, so I just removed it.

I can't see anything which this breaks, and now things look sparkly again:

![image](https://user-images.githubusercontent.com/10621139/54790009-69deec80-4c2c-11e9-8473-8783bf26de0e.png)

The only CSS I can see relating to this is [here](https://github.com/Alsciende/netrunnerdb/blob/d2d92333709685ffb36dc7280a5e36380046d312/web/css/style.css#L533-L543):

```
/******** fix for twitter typehead + bootstrap input-group-btn ***********/


.input-group .twitter-typeahead {
	top: 3px;
}
.input-group .twitter-typeahead:last-child input.form-control.tt-input {
    border-radius: 0 4px 4px 0;
}
.input-group .twitter-typeahead:first-child input.form-control.tt-input {
	border-radius: 4px 0 0 4px;
}
```

Anyone got any better ideas, or should we merge this and walk away whistling? 😄 