### PR TITLE
Make <em> within FT render as non-italic

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -9,6 +9,7 @@ body {font-size:16px;font-family: 'LatoWeb', sans-serif;}
 .card-text sup{line-height:0;font-size:x-small}
 .card-text p{margin:6px}
 .card-flavor{font-style:italic}
+.card-flavor em{font-style:normal}
 .pack-future, .card-preview{color:red}
 /* */
 


### PR DESCRIPTION
`<em>` tags are used occasionally within flavor text to indicate emphasis, as seen in cards like Mache and Too Big to Fail. Semantically, this is sound, but stylistically, the emphasis is not being displayed (because the text is already italic). This fix makes `<em>` tags within the "card-flavor" class render as `font-style: normal`.