### PR TITLE
Display rotated icon

### DIFF
--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -19,7 +19,16 @@
                                 <div class="panel-heading">
                                     <h3 class="panel-title card-title">
                                         {% if card.uniqueness == true %}&diams;{% endif %}
-                                        <a href="{{ card.url }}" class="card-title{% if card.available == false %} card-preview{% endif %}">{{ card.title }}</a>
+                                        <a href="{{ card.url }}" class="card-title{% if card.available == false %} card-preview{% endif %}">{{ card.title }}</a> 
+					{% if card.mwl_info|length %}
+					    {% if card.mwl_info[0].is_restricted %}
+					        <span title="Restricted card">&#x1f984;</span>
+					    {% endif%}
+					    {% if card.mwl_info[0].deck_limit is not null and card.mwl_info[0].deck_limit == 0 %}
+						<span title="Banned card"><font color="red">&cross;</font></span>
+					    {% endif %}
+                                        {% endif %}
+
                                     </h3>
                                 </div>
                                 <div class="panel-body">

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -28,6 +28,9 @@
 						<span title="Banned card"><font color="red">&#x1f6ab;</font></span>
 					    {% endif %}
                                         {% endif %}
+					{% if card.is_rotated %}
+					    <span title="Rotated card">&#x1f504;</span>	
+					{% endif %}
                                     </h3>
                                 </div>
                                 <div class="panel-body">

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -25,10 +25,9 @@
 					        <span title="Restricted card">&#x1f984;</span>
 					    {% endif%}
 					    {% if card.mwl_info[0].deck_limit is not null and card.mwl_info[0].deck_limit == 0 %}
-						<span title="Banned card"><font color="red">&cross;</font></span>
+						<span title="Banned card"><font color="red">&#x1f6ab;</font></span>
 					    {% endif %}
                                         {% endif %}
-
                                     </h3>
                                 </div>
                                 <div class="panel-body">

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -445,6 +445,8 @@ class SearchController extends Controller
                     $cardinfo['reviews'] = $cardsData->get_reviews($cardVersions);
                     $cardinfo['rulings'] = $cardsData->get_rulings($cardVersions);
                     $cardinfo['mwl_info'] = $cardsData->get_mwl_info($cardVersions);
+
+		    $cardinfo['is_rotated'] = $card->getPack()->getCycle()->getRotated();
                 }
                 if ($view == "rulings") {
                     $cardinfo['rulings'] = $cardsData->get_rulings(array($card));

--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -263,6 +263,14 @@ function unicorn(card) {
     return mwlCard.is_restricted ? unicorn_emoji : '';
 }
 
+function check_card_rotation(card) {
+    var rotated_cycles = _.map(NRDB.data.cycles.find( { "rotated": true } ), 'code');
+    var is_rotated = rotated_cycles.find(function(c) {return c === card.pack.cycle_code;});
+
+    var rotated_emoji = ' <span title="Rotated card" style="display:inline-block;width:1.5em;">&#x1f504;</span> ';
+    return is_rotated ? rotated_emoji : '';
+}
+
 function update_deck(options) {
     var restrainOneColumn = false;
     if (options) {
@@ -336,7 +344,7 @@ function update_deck(options) {
     var cabinet = {};
     var parts = Identity.title.split(/: /);
 
-    $('#identity').html('<a href="' + Routing.generate('cards_zoom', { card_code: Identity.code }) + '" data-target="#cardModal" data-remote="false" class="card" data-toggle="modal" data-index="' + Identity.code + '">' + parts[0] + ' <small>' + parts[1] + '</small></a>' + unicorn(Identity));
+    $('#identity').html('<a href="' + Routing.generate('cards_zoom', { card_code: Identity.code }) + '" data-target="#cardModal" data-remote="false" class="card" data-toggle="modal" data-index="' + Identity.code + '">' + parts[0] + ' <small>' + parts[1] + '</small></a>' + check_card_rotation(Identity) + unicorn(Identity));
     $('#img_identity').prop('src', Identity.imageUrl);
     InfluenceLimit = Identity.influence_limit;
     if (typeof InfluenceLimit === "undefined")
@@ -440,7 +448,7 @@ function update_deck(options) {
             additional_info = '(<span class="small icon icon-' + card.pack.cycle.code + '"></span> ' + card.position + ') ' + alert_number_of_sets + influence;
         }
 
-        var item = $('<div>' + card.indeck + 'x <a href="' + Routing.generate('cards_zoom', { card_code: card.code }) + '" class="card" data-toggle="modal" data-remote="false" data-target="#cardModal" data-index="' + card.code + '">' + card.title + '</a>' + unicorn(card) + additional_info + '</div>');
+        var item = $('<div>' + card.indeck + 'x <a href="' + Routing.generate('cards_zoom', { card_code: card.code }) + '" class="card" data-toggle="modal" data-remote="false" data-target="#cardModal" data-index="' + card.code + '">' + card.title + '</a>' + check_card_rotation(card) + unicorn(card) + additional_info + '</div>');
         item.appendTo($('#deck-content .deck-' + criteria));
 
         cabinet[criteria] |= 0;


### PR DESCRIPTION
Displays 🔄 besides rotated cards in decklist page, and banned and restricted icons on card page.　This partially solves issue #214.

I accept suggestions for the "banned" icon.