### PR TITLE
Use the correct variable for the MWL on the deck view page.

### DIFF
--- a/web/js/deckview.js
+++ b/web/js/deckview.js
@@ -13,7 +13,7 @@ $(document).on('data.app', function() {
 		});
 	});
 
-	var mwl_code = SelectedDeck.mwl_code, mwl_record = mwl_code && NRDB.data.mwl.findById(mwl_code);
+	var mwl_code = SelectedDeck.code, mwl_record = mwl_code && NRDB.data.mwl.findById(mwl_code);
 	MWL = mwl_record;
 
 	update_deck();

--- a/web/js/deckview.js
+++ b/web/js/deckview.js
@@ -13,8 +13,7 @@ $(document).on('data.app', function() {
 		});
 	});
 
-	var mwl_code = SelectedDeck.code, mwl_record = mwl_code && NRDB.data.mwl.findById(mwl_code);
-	MWL = mwl_record;
+	MWL = SelectedDeck.code && NRDB.data.mwl.findById(SelectedDeck.code);
 
 	update_deck();
 	NRDB.draw_simulator.init();


### PR DESCRIPTION
Since the MWL code was undefined, the status indicators aren't present on the deck view page.  This includes things like the unicorn icon and the older MWL stars.

This fixes issue #95.

Before:
![Screenshot 2019-05-27 at 10 52 08 AM](https://user-images.githubusercontent.com/396562/58430314-7a697400-806e-11e9-8c5a-c95d3c7d95e2.png)

After:
![Screenshot 2019-05-27 at 10 56 02 AM](https://user-images.githubusercontent.com/396562/58430318-82c1af00-806e-11e9-8d34-b4e91caedfef.png)

