### PR TITLE
Be defensive against decks with no mwl set (casual play).

### DIFF
--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -438,7 +438,10 @@ class BuilderController extends Controller
             );
         }
 
-        $mwl = $deck->getMWL()->getCards();
+        $mwl = null;
+	if ($deck->getMWL()) {
+		$mwl = $deck->getMWL()->getCards();
+	}
         foreach ($types as $type) {
             if (isset($classement[$type]) && $classement[$type]['qty']) {
                 $lines[] = "";
@@ -449,7 +452,8 @@ class BuilderController extends Controller
                     /** @var Card $card */
                     $card = $slot['card'];
                     $is_restricted = (
-                        isset($mwl[$card->getCode()])
+			$mwl
+                        && isset($mwl[$card->getCode()])
                         && isset($mwl[$card->getCode()]['is_restricted'])
                         && ($mwl[$card->getCode()]['is_restricted'] === 1)
                     );

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -678,7 +678,10 @@ class SocialController extends Controller
             );
         }
 
-        $mwl = $decklist->getMWL()->getCards();
+        $mwl = null;
+        if ($decklist->getMWL()) {
+          $mwl = $decklist->getMWL()->getCards();
+	}
         foreach ($types as $type) {
             if (isset($classement[$type]) && $classement[$type]['qty']) {
                 $lines[] = "";
@@ -689,7 +692,8 @@ class SocialController extends Controller
                     /** @var Card $card */
                     $card = $slot['card'];
                     $is_restricted = (
-                        isset($mwl[$card->getCode()])
+			$mwl
+                        && isset($mwl[$card->getCode()])
                         && isset($mwl[$card->getCode()]['is_restricted'])
                         && ($mwl[$card->getCode()]['is_restricted'] === 1)
                     );


### PR DESCRIPTION
A NULL mwl_id in the deck or dceklist table was previously leading
to a crash like:
  Call to a member function getCards() on null

I need to follow this up with some refactoring to share this code between the two controllers.  The way ti is set up and duplicated now is silly.

Fixes #348