### PR TITLE
Retrieve deck size properly in the decklist text export code path.

### DIFF
--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -739,7 +739,7 @@ class SocialController extends Controller
         );
 
         if ($decklist->getSide()->getCode() == "corp") {
-            $minAgendaPoints = floor($decklist->getDeckSize() / 5) * 2 + 2;
+            $minAgendaPoints = floor($classement['deckSize'] / 5) * 2 + 2;
 
             $lines[] = sprintf(
                 "%s agenda points (between %s and %s)",


### PR DESCRIPTION
decklist objects don't have a deckSize() method, like a deck does.

Should really fix #348.