### PR TITLE
Add markdown support for comments, including a preview box.

### DIFF
--- a/src/AppBundle/Controller/ReviewController.php
+++ b/src/AppBundle/Controller/ReviewController.php
@@ -361,11 +361,12 @@ class ReviewController extends Controller
     /**
      * @param Request                $request
      * @param EntityManagerInterface $entityManager
+     * @param TextProcessor          $textProcessor
      * @return Response
      *
      * @IsGranted("IS_AUTHENTICATED_REMEMBERED")
      */
-    public function commentAction(Request $request, EntityManagerInterface $entityManager)
+    public function commentAction(Request $request, EntityManagerInterface $entityManager, TextProcessor $textProcessor)
     {
         $user = $this->getUser();
 
@@ -385,7 +386,12 @@ class ReviewController extends Controller
         $comment = new Reviewcomment();
         $comment->setReview($review);
         $comment->setAuthor($user);
-        $comment->setText($comment_text);
+        $comment_html = $textProcessor->markdown($comment_text);
+        if (!$comment_html) {
+            return new Response('Your comment is empty.');
+        }
+
+        $comment->setText($comment_html);
 
         $entityManager->persist($comment);
 


### PR DESCRIPTION
This addresses enhancement request #280 

Published version:
![Screenshot 2019-12-28 at 3 20 40 PM](https://user-images.githubusercontent.com/396562/71549630-3e8ce900-2986-11ea-94ae-1d15d201bdb9.png)

Preview while editing.
![Screenshot 2019-12-28 at 3 21 13 PM](https://user-images.githubusercontent.com/396562/71549631-40ef4300-2986-11ea-938e-92097e15b40d.png)

Reviews have both rawtext and text fields, but I didn't do that here.  I certainly can if we think it is worth it.  This leaves existing comments alone and only new comments will have this functionality.