### PR TITLE
Add a preview to the publish deck flows

### DIFF
--- a/app/Resources/views/Builder/decks.html.twig
+++ b/app/Resources/views/Builder/decks.html.twig
@@ -312,11 +312,10 @@ var Identity = null,
 								<label for="publish-deck-description">Description</label>
 								<textarea class="form-control" name="description" id="publish-deck-description" rows="5" placeholder="Enter a brief explanation of the deck strategy and your significant choices"></textarea>
 							</div>
-<div>
-<small>Description Preview. Look <a href="http://daringfireball.net/projects/markdown/dingus">here</a> for a Markdown syntax reference.</small>
-</div>
-<div class="well text-muted" id="publish-deck-description-preview">
-</div>
+							<div>
+								<small>Description Preview. Look <a href="http://daringfireball.net/projects/markdown/dingus">here</a> for a Markdown syntax reference.</small>
+							</div>
+							<div class="well text-muted" id="publish-deck-description-preview"></div>
 
 							<div class="form-group">
 								<label for="edit-decklist-tournament">Placed high in a tournament (Store Championship and better)</label>

--- a/app/Resources/views/Builder/decks.html.twig
+++ b/app/Resources/views/Builder/decks.html.twig
@@ -1,3 +1,4 @@
+
 {% extends '/layout.html.twig' %}
 {% block head %}
 <script src="{{ asset('/js/nrdb.card_modal.js') }}"></script>
@@ -311,6 +312,12 @@ var Identity = null,
 								<label for="publish-deck-description">Description</label>
 								<textarea class="form-control" name="description" id="publish-deck-description" rows="5" placeholder="Enter a brief explanation of the deck strategy and your significant choices"></textarea>
 							</div>
+<div>
+<small>Description Preview. Look <a href="http://daringfireball.net/projects/markdown/dingus">here</a> for a Markdown syntax reference.</small>
+</div>
+<div class="well text-muted" id="publish-deck-description-preview">
+</div>
+
 							<div class="form-group">
 								<label for="edit-decklist-tournament">Placed high in a tournament (Store Championship and better)</label>
 								<select class="form-control" name="tournament" id="edit-decklist-tournament">

--- a/app/Resources/views/Builder/deckview.html.twig
+++ b/app/Resources/views/Builder/deckview.html.twig
@@ -309,6 +309,11 @@ var Identity = null,
 								<label for="publish-name">Description</label>
 								<textarea class="form-control" name="description" id="publish-deck-description" rows="5" placeholder="Enter a brief explanation of the deck strategy and your significant choices"></textarea>
 							</div>
+<div>
+<small>Description Preview. Look <a href="http://daringfireball.net/projects/markdown/dingus">here</a> for a Markdown syntax reference.</small>
+</div>
+<div class="well text-muted" id="publish-deck-description-preview">
+</div>
 							<div class="form-group">
 								<label for="edit-decklist-tournament">Placed high in a tournament (Store Championship and better)</label>
 								<select class="form-control" name="tournament" id="edit-decklist-tournament">

--- a/app/Resources/views/Builder/deckview.html.twig
+++ b/app/Resources/views/Builder/deckview.html.twig
@@ -309,11 +309,10 @@ var Identity = null,
 								<label for="publish-name">Description</label>
 								<textarea class="form-control" name="description" id="publish-deck-description" rows="5" placeholder="Enter a brief explanation of the deck strategy and your significant choices"></textarea>
 							</div>
-<div>
-<small>Description Preview. Look <a href="http://daringfireball.net/projects/markdown/dingus">here</a> for a Markdown syntax reference.</small>
-</div>
-<div class="well text-muted" id="publish-deck-description-preview">
-</div>
+							<div>
+								<small>Description Preview. Look <a href="http://daringfireball.net/projects/markdown/dingus">here</a> for a Markdown syntax reference.</small>
+							</div>
+							<div class="well text-muted" id="publish-deck-description-preview"></div>
 							<div class="form-group">
 								<label for="edit-decklist-tournament">Placed high in a tournament (Store Championship and better)</label>
 								<select class="form-control" name="tournament" id="edit-decklist-tournament">

--- a/web/js/decks.js
+++ b/web/js/decks.js
@@ -440,64 +440,61 @@ function confirm_publish(deck) {
 	$('#publish-form-warning').remove();
 	$('#btn-publish-submit').text("Checking...").prop('disabled', true);
 	$.ajax(Routing.generate('deck_publish', {deck_id:deck.id}), {
-	  success: function( response ) {
-		  var type = response.allowed ? 'warning' : 'danger';
-		  if(response.message) {
-			  $('#publish-deck-form').prepend('<div id="publish-form-warning" class="alert alert-'+type+'">'+response.message+'</div>');
-		  }
-		  if(response.allowed) {
-			  $('#btn-publish-submit').text("Go").prop('disabled', false);
-		  }
-    var converter = new Markdown.Converter();
-    $('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
-    $('#publish-deck-description').on(
-            'keyup',
-            function () {
-                $('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
-            }
-    );
+		success: function( response ) {
+			var type = response.allowed ? 'warning' : 'danger';
+			if(response.message) {
+				$('#publish-deck-form').prepend('<div id="publish-form-warning" class="alert alert-'+type+'">'+response.message+'</div>');
+			}
+			if (response.allowed) {
+				$('#btn-publish-submit').text("Go").prop('disabled', false);
+			}
+			var converter = new Markdown.Converter();
+			$('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
+			$('#publish-deck-description').on(
+				'keyup',
+				function () {
+					$('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
+				}
+			);
 
-    $('#publish-deck-description').textcomplete([{
-            match: /\B#([\-+\w]*)$/,
-            search: function (term, callback) {
-                var regexp = new RegExp('\\b' + term, 'i');
-                callback(NRDB.data.cards.find({
-                    title: regexp
-                }));
-            },
-            template: function (value) {
-                return value.title;
-            },
-            replace: function (value) {
-                return '[' + value.title + ']('
-                        + Routing.generate('cards_zoom', {card_code: value.code})
-                        + ')';
-            },
-            index: 1
-        }, {
-            match: /\$([\-+\w]*)$/,
-            search: function (term, callback) {
-                var regexp = new RegExp('^' + term);
-                callback($.grep(['credit', 'recurring-credit', 'click', 'link', 'trash', 'subroutine', 'mu', '1mu', '2mu', '3mu',
-                    'anarch', 'criminal', 'shaper', 'haas-bioroid', 'weyland-consortium', 'jinteki', 'nbn'],
-                        function (symbol) {
-                            return regexp.test(symbol);
-                        }
-                ));
-            },
-            template: function (value) {
-                return value;
-            },
-            replace: function (value) {
-                return '<span class="icon icon-' + value + '"></span>';
-            },
-            index: 1
-        }]);
-	  },
-	  error: function( jqXHR, textStatus, errorThrown ) {
+			$('#publish-deck-description').textcomplete([
+				{
+					match: /\B#([\-+\w]*)$/,
+					search: function (term, callback) {
+						var regexp = new RegExp('\\b' + term, 'i');
+						callback(NRDB.data.cards.find({
+						title: regexp
+						}));
+					},
+					template: function (value) { return value.title; },
+					replace: function (value) {
+						return '[' + value.title + ']('
+							+ Routing.generate('cards_zoom', {card_code: value.code})
+							+ ')';
+					},
+					index: 1
+				},
+				{
+					match: /\$([\-+\w]*)$/,
+					search: function (term, callback) {
+						var regexp = new RegExp('^' + term);
+						callback($.grep(
+								// TODO(plural): Extract this out somewhere and insure it has all the right symbols.
+								['credit', 'recurring-credit', 'click', 'link', 'trash', 'subroutine', 'mu', '1mu', '2mu', '3mu', 'anarch', 'criminal', 'shaper', 'haas-bioroid', 'weyland-consortium', 'jinteki', 'nbn'],
+								function (symbol) { return regexp.test(symbol); }
+						));
+					},
+					template: function (value) { return value; },
+					replace: function (value) {
+						return '<span class="icon icon-' + value + '"></span>';
+					},
+					index: 1
+				}]);
+		},
+		error: function( jqXHR, textStatus, errorThrown ) {
 			console.log('['+moment().format('YYYY-MM-DD HH:mm:ss')+'] Error on '+this.url, textStatus, errorThrown);
-	    $('#publish-deck-form').prepend('<div id="publish-form-alert" class="alert alert-danger">'+jqXHR.responseText+'</div>');
-	  }
+			$('#publish-deck-form').prepend('<div id="publish-form-alert" class="alert alert-danger">'+jqXHR.responseText+'</div>');
+		}
 	});
 	$('#publish-deck-name').val(deck.name);
 	$('#publish-deck-id').val(deck.id);

--- a/web/js/decks.js
+++ b/web/js/decks.js
@@ -448,6 +448,51 @@ function confirm_publish(deck) {
 		  if(response.allowed) {
 			  $('#btn-publish-submit').text("Go").prop('disabled', false);
 		  }
+    var converter = new Markdown.Converter();
+    $('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
+    $('#publish-deck-description').on(
+            'keyup',
+            function () {
+                $('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
+            }
+    );
+
+    $('#publish-deck-description').textcomplete([{
+            match: /\B#([\-+\w]*)$/,
+            search: function (term, callback) {
+                var regexp = new RegExp('\\b' + term, 'i');
+                callback(NRDB.data.cards.find({
+                    title: regexp
+                }));
+            },
+            template: function (value) {
+                return value.title;
+            },
+            replace: function (value) {
+                return '[' + value.title + ']('
+                        + Routing.generate('cards_zoom', {card_code: value.code})
+                        + ')';
+            },
+            index: 1
+        }, {
+            match: /\$([\-+\w]*)$/,
+            search: function (term, callback) {
+                var regexp = new RegExp('^' + term);
+                callback($.grep(['credit', 'recurring-credit', 'click', 'link', 'trash', 'subroutine', 'mu', '1mu', '2mu', '3mu',
+                    'anarch', 'criminal', 'shaper', 'haas-bioroid', 'weyland-consortium', 'jinteki', 'nbn'],
+                        function (symbol) {
+                            return regexp.test(symbol);
+                        }
+                ));
+            },
+            template: function (value) {
+                return value;
+            },
+            replace: function (value) {
+                return '<span class="icon icon-' + value + '"></span>';
+            },
+            index: 1
+        }]);
 	  },
 	  error: function( jqXHR, textStatus, errorThrown ) {
 			console.log('['+moment().format('YYYY-MM-DD HH:mm:ss')+'] Error on '+this.url, textStatus, errorThrown);

--- a/web/js/deckview.js
+++ b/web/js/deckview.js
@@ -71,64 +71,62 @@ function confirm_publish() {
 	$('#publish-form-warning').remove();
 	$('#btn-publish-submit').text("Checking...").prop('disabled', true);
 	$.ajax(Routing.generate('deck_publish', {deck_id:SelectedDeck.id}), {
-	  success: function( response ) {
-		  var type = response.allowed ? 'warning' : 'danger';
-		  if(response.message) {
-			  $('#publish-deck-form').prepend('<div id="publish-form-warning" class="alert alert-'+type+'">'+response.message+'</div>');
-		  }
-		  if(response.allowed) {
-			  $('#btn-publish-submit').text("Go").prop('disabled', false);
-		  }
-    var converter = new Markdown.Converter();
-    $('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
-    $('#publish-deck-description').on(
-            'keyup',
-            function () {
-                $('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
-            }
-    );
+		success: function( response ) {
+			var type = response.allowed ? 'warning' : 'danger';
+			if(response.message) {
+				$('#publish-deck-form').prepend('<div id="publish-form-warning" class="alert alert-'+type+'">'+response.message+'</div>');
+			}
+			if (response.allowed) {
+				$('#btn-publish-submit').text("Go").prop('disabled', false);
+			}
 
-    $('#publish-deck-description').textcomplete([{
-            match: /\B#([\-+\w]*)$/,
-            search: function (term, callback) {
-                var regexp = new RegExp('\\b' + term, 'i');
-                callback(NRDB.data.cards.find({
-                    title: regexp
-                }));
-            },
-            template: function (value) {
-                return value.title;
-            },
-            replace: function (value) {
-                return '[' + value.title + ']('
-                        + Routing.generate('cards_zoom', {card_code: value.code})
-                        + ')';
-            },
-            index: 1
-        }, {
-            match: /\$([\-+\w]*)$/,
-            search: function (term, callback) {
-                var regexp = new RegExp('^' + term);
-                callback($.grep(['credit', 'recurring-credit', 'click', 'link', 'trash', 'subroutine', 'mu', '1mu', '2mu', '3mu',
-                    'anarch', 'criminal', 'shaper', 'haas-bioroid', 'weyland-consortium', 'jinteki', 'nbn'],
-                        function (symbol) {
-                            return regexp.test(symbol);
-                        }
-                ));
-            },
-            template: function (value) {
-                return value;
-            },
-            replace: function (value) {
-                return '<span class="icon icon-' + value + '"></span>';
-            },
-            index: 1
-        }]);
-	  },
-	  error: function( jqXHR, textStatus, errorThrown ) {
+			var converter = new Markdown.Converter();
+			$('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
+			$('#publish-deck-description').on(
+				'keyup',
+				function () {
+					$('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
+				}
+			);
+
+			$('#publish-deck-description').textcomplete([
+				{
+					match: /\B#([\-+\w]*)$/,
+					search: function (term, callback) {
+						var regexp = new RegExp('\\b' + term, 'i');
+						callback(NRDB.data.cards.find({
+						title: regexp
+						}));
+					},
+					template: function (value) { return value.title; },
+					replace: function (value) {
+						return '[' + value.title + ']('
+							+ Routing.generate('cards_zoom', {card_code: value.code})
+							+ ')';
+					},
+					index: 1
+				},
+				{
+					match: /\$([\-+\w]*)$/,
+					search: function (term, callback) {
+						var regexp = new RegExp('^' + term);
+						callback($.grep(
+								// TODO(plural): Extract this out somewhere and insure it has all the right symbols.
+								['credit', 'recurring-credit', 'click', 'link', 'trash', 'subroutine', 'mu', '1mu', '2mu', '3mu', 'anarch', 'criminal', 'shaper', 'haas-bioroid', 'weyland-consortium', 'jinteki', 'nbn'],
+								function (symbol) { return regexp.test(symbol); }
+						));
+					},
+					template: function (value) { return value; },
+					replace: function (value) {
+						return '<span class="icon icon-' + value + '"></span>';
+					},
+					index: 1
+				}]);
+		},
+		error: function( jqXHR, textStatus, errorThrown ) {
 			console.log('['+moment().format('YYYY-MM-DD HH:mm:ss')+'] Error on '+this.url, textStatus, errorThrown);
-	    $('#publish-deck-form').prepend('<div id="publish-form-alert" class="alert alert-danger">'+jqXHR.responseText+'</div>');
-	  }
+			$('#publish-deck-form').prepend('<div id="publish-form-alert" class="alert alert-danger">'+jqXHR.responseText+'</div>');
+		}
 	});
 	$('#publish-deck-name').val(SelectedDeck.name);
 	$('#publish-deck-id').val(SelectedDeck.id);

--- a/web/js/deckview.js
+++ b/web/js/deckview.js
@@ -1,4 +1,5 @@
 
+
 $(document).on('data.app', function() {
 	var sets_in_deck = {};
 	NRDB.data.cards.find().forEach(function(card) {
@@ -78,6 +79,51 @@ function confirm_publish() {
 		  if(response.allowed) {
 			  $('#btn-publish-submit').text("Go").prop('disabled', false);
 		  }
+    var converter = new Markdown.Converter();
+    $('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
+    $('#publish-deck-description').on(
+            'keyup',
+            function () {
+                $('#publish-deck-description-preview').html(converter.makeHtml($('#publish-deck-description').val()));
+            }
+    );
+
+    $('#publish-deck-description').textcomplete([{
+            match: /\B#([\-+\w]*)$/,
+            search: function (term, callback) {
+                var regexp = new RegExp('\\b' + term, 'i');
+                callback(NRDB.data.cards.find({
+                    title: regexp
+                }));
+            },
+            template: function (value) {
+                return value.title;
+            },
+            replace: function (value) {
+                return '[' + value.title + ']('
+                        + Routing.generate('cards_zoom', {card_code: value.code})
+                        + ')';
+            },
+            index: 1
+        }, {
+            match: /\$([\-+\w]*)$/,
+            search: function (term, callback) {
+                var regexp = new RegExp('^' + term);
+                callback($.grep(['credit', 'recurring-credit', 'click', 'link', 'trash', 'subroutine', 'mu', '1mu', '2mu', '3mu',
+                    'anarch', 'criminal', 'shaper', 'haas-bioroid', 'weyland-consortium', 'jinteki', 'nbn'],
+                        function (symbol) {
+                            return regexp.test(symbol);
+                        }
+                ));
+            },
+            template: function (value) {
+                return value;
+            },
+            replace: function (value) {
+                return '<span class="icon icon-' + value + '"></span>';
+            },
+            index: 1
+        }]);
 	  },
 	  error: function( jqXHR, textStatus, errorThrown ) {
 			console.log('['+moment().format('YYYY-MM-DD HH:mm:ss')+'] Error on '+this.url, textStatus, errorThrown);


### PR DESCRIPTION
This addresses issue #179 

Publishing a decklist now has the same preview functionality as other parts of the site including symbol replacement with $ and card replacement with #.  This should make it easier to see exactly what you are going to publish.

Before:
![publish decklist pop-up](https://user-images.githubusercontent.com/396562/71551969-dfe06300-29b7-11ea-9c53-e91ebad2b4a8.png)

After:
![Screenshot 2019-12-28 at 7 20 44 PM](https://user-images.githubusercontent.com/396562/71551971-eec71580-29b7-11ea-8b45-068504a43ff0.png)
![Screenshot 2019-12-28 at 7 26 26 PM](https://user-images.githubusercontent.com/396562/71551972-f090d900-29b7-11ea-833e-a982a485a6c6.png)

