### PR TITLE
Fix published decklist comparison functionality from the decklist page.

### DIFF
--- a/web/js/decklist.js
+++ b/web/js/decklist.js
@@ -293,6 +293,7 @@ $(function () {
     $(document).on('click', '#btn-export-markdown', export_markdown);
     $(document).on('click', '#btn-export-plaintext', export_plaintext);
     $(document).on('click', '#btn-export-jintekinet', export_jintekinet);
+    $(document).on('click', '#btn-compare', compare_form);
     $(document).on('click', '#btn-compare-submit', compare_submit);
     $(document).on('click', '#btn-copy-decklist', copy_decklist);
     $(document).on('click', '#btn-moderation-absolve', moderation_absolve);


### PR DESCRIPTION
The menu item just wasn't wired up to the javascript to bring up the UI for the comparison.

This fixes #279 

Dialog after clicking "Compare with another decklist"
![decklist-comparison-dialog](https://user-images.githubusercontent.com/396562/71561099-abac8700-2a37-11ea-8b5e-353eba68b880.png)

Decklist Comparison View
![decklist-comparison-diff](https://user-images.githubusercontent.com/396562/71561101-ae0ee100-2a37-11ea-9e5e-2670853b2bf5.png)
