### PR TITLE
Card completion everywhere!!!!

### DIFF
--- a/app/Resources/views/Search/advanced-search.html.twig
+++ b/app/Resources/views/Search/advanced-search.html.twig
@@ -6,6 +6,45 @@
 <div class="container">
 
     <script type="text/javascript">
+        Promise.all([NRDB.data.promise, NRDB.ui.promise]).then(function() {
+            // TODO(plural): Find a better place for this and remove the duplicate definitions.
+            // This will filter matchingCards to only the latest version of each card, preserving the original order of matchingCards.
+            function select_only_latest_cards(matchingCards) {
+                var latestCardsByTitle = {};
+                for (var card of matchingCards) {
+                    var latestCard = latestCardsByTitle[card.title];
+                    if (!latestCard || card.code > latestCard.code) {
+                        latestCardsByTitle[card.title] = card;
+                    }
+                }
+                return matchingCards.filter(function(value, index, arr) {
+                    return value.code == latestCardsByTitle[value.title].code;
+                });
+            }
+
+            // We only need to calculate the latest_cards once and not on every findMatches call.
+            var latest_cards = select_only_latest_cards(NRDB.data.cards.find());
+
+            function findMatches(q, cb) {
+                if (q.match(/^\w:/)) { return; }
+
+                var regexp = new RegExp(q, 'i');
+                var matchingCards = _.filter(latest_cards, function (card) {
+                    return regexp.test(_.deburr(card.title).toLowerCase().trim());
+                });
+                cb(_.sortBy(matchingCards, 'title'));
+            }
+
+            $('#q').typeahead({
+                hint: true,
+                highlight: true,
+                minLength: 2
+            }, {
+                display: function(card) { return card.title; },
+                source: findMatches
+            });
+        });
+
         $(function () {
             $('#faction-select').multiselect({
                 buttonWidth: '100%'
@@ -18,7 +57,7 @@
         <div class="col">
 
             <h1>{{ block('title') }}</h1>
-            <form method="GET" action="{{ path('cards_processSearchForm') }}" role="form" style="margin-bottom:2em">
+            <form id="advanced_search_form" method="GET" action="{{ path('cards_processSearchForm') }}" role="form" style="margin-bottom:2em">
 
                 <fieldset>
                     <legend>Title and texts</legend>
@@ -27,7 +66,7 @@
                             <div class="form-group">
                                 <label for="q">Title</label>
                                 <div class="input-group">
-                                    <input class="form-control" size="200" id="q" name="q" value="">
+                                    <input class="form-control" placeholder="Card Search" size="200" id="q" name="q" value="">
                                 </div>
                             </div>
                         </div>

--- a/app/Resources/views/Search/searchbar.html.twig
+++ b/app/Resources/views/Search/searchbar.html.twig
@@ -1,3 +1,47 @@
+    <script type="text/javascript">
+        Promise.all([NRDB.data.promise, NRDB.ui.promise]).then(function() {
+            // TODO(plural): Find a better place for this and remove the duplicate definitions.
+            // This will filter matchingCards to only the latest version of each card, preserving the original order of matchingCards.
+            function select_only_latest_cards(matchingCards) {
+                var latestCardsByTitle = {};
+                for (var card of matchingCards) {
+                    var latestCard = latestCardsByTitle[card.title];
+                    if (!latestCard || card.code > latestCard.code) {
+                        latestCardsByTitle[card.title] = card;
+                    }
+                }
+                return matchingCards.filter(function(value, index, arr) {
+                    return value.code == latestCardsByTitle[value.title].code;
+                });
+            }
+
+            // We only need to calculate the latest_cards once and not on every findMatches call.
+            var latest_cards = select_only_latest_cards(NRDB.data.cards.find());
+
+            function findMatches(q, cb) {
+                if (q.match(/^\w:/)) { return; }
+
+                var regexp = new RegExp(q, 'i');
+                var matchingCards = _.filter(latest_cards, function (card) {
+                    return regexp.test(_.deburr(card.title).toLowerCase().trim());
+                });
+                cb(_.sortBy(matchingCards, 'title'));
+            }
+
+            $('#search-input').typeahead({
+                hint: true,
+                highlight: true,
+                minLength: 2
+            }, {
+                display: function(card) { return card.title; },
+                source: findMatches
+            });
+            $('#search-input').on('typeahead:selected typeahead:autocomplete', function(event, data) {
+                $('#search-input').typeahead('val', data.code);
+            });
+        });
+    </script>
+
 <div class="row">
 	<form method="GET" action="{{ path('cards_find') }}" id="search-form" role="form">
 		<div class="col-sm-4">

--- a/app/Resources/views/Search/searchbar.html.twig
+++ b/app/Resources/views/Search/searchbar.html.twig
@@ -1,28 +1,12 @@
     <script type="text/javascript">
         Promise.all([NRDB.data.promise, NRDB.ui.promise]).then(function() {
-            // TODO(plural): Find a better place for this and remove the duplicate definitions.
-            // This will filter matchingCards to only the latest version of each card, preserving the original order of matchingCards.
-            function select_only_latest_cards(matchingCards) {
-                var latestCardsByTitle = {};
-                for (var card of matchingCards) {
-                    var latestCard = latestCardsByTitle[card.title];
-                    if (!latestCard || card.code > latestCard.code) {
-                        latestCardsByTitle[card.title] = card;
-                    }
-                }
-                return matchingCards.filter(function(value, index, arr) {
-                    return value.code == latestCardsByTitle[value.title].code;
-                });
-            }
-
-            // We only need to calculate the latest_cards once and not on every findMatches call.
-            var latest_cards = select_only_latest_cards(NRDB.data.cards.find());
+            var all_cards = NRDB.data.cards.find();
 
             function findMatches(q, cb) {
                 if (q.match(/^\w:/)) { return; }
 
                 var regexp = new RegExp(q, 'i');
-                var matchingCards = _.filter(latest_cards, function (card) {
+                var matchingCards = _.filter(all_cards, function (card) {
                     return regexp.test(_.deburr(card.title).toLowerCase().trim());
                 });
                 cb(_.sortBy(matchingCards, 'title'));
@@ -33,7 +17,7 @@
                 highlight: true,
                 minLength: 2
             }, {
-                display: function(card) { return card.title; },
+                display: function(card) { return card.title + ' (' + card.pack.name + ')'; },
                 source: findMatches
             });
             $('#search-input').on('typeahead:selected typeahead:autocomplete', function(event, data) {

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -92,6 +92,7 @@
     <script src="{{ asset('/js/nrdb.format.js') }}"></script>
     <script src="{{ asset('/js/nrdb.tip.js') }}"></script>
     <script src="{{ asset('/js/nrdb.ui.js') }}"></script>
+    <script src="{{ asset('/js/topnav.js') }}"></script>
 
     {% block head %}{% endblock %}
 
@@ -138,11 +139,11 @@
               <li><a href="{{ path('card_rulings') }}">Rulings</a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
-              <li class="dropdown hidden-xs hidden-lg">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="glyphicon glyphicon-search"></span></a>
-                <div class="dropdown-menu">
-                  <form method="get" action="{{ path('cards_find') }}">
-                    <input type="text" placeholder="Card Search" class="form-control" name="q" title="{% include '/Search/searchtooltip.html.twig' %}">
+              <li class="dropdown" id="top_nav_card_search_menu">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Card Search&nbsp;&nbsp;<span class="glyphicon glyphicon-search"></span></a>
+                <div class="dropdown-menu" id="miney">
+                  <form id="top_nav_card_search_form" method="get" action="{{ path('cards_find') }}">
+                    <input type="text" placeholder="Card Search" class="form-control" name="q" id="top_nav_card_search" title="{% include '/Search/searchtooltip.html.twig' %}">
                   </form>
                 </div>
               </li>
@@ -153,11 +154,6 @@
                 <a href="#" class="dropdown-toggle loginname" data-toggle="dropdown"><span class="glyphicon glyphicon-user"></span><b class="caret"></b></a>
               </li>
             </ul>
-            <form class="navbar-form navbar-right visible-lg-block visible-xs-block" action="{{ path('cards_find') }}">
-              <div class="form-group">
-                <input type="text" placeholder="Card Search" class="form-control" name="q" title="{% include '/Search/searchtooltip.html.twig' %}">
-              </div>
-            </form>
           </div><!--/.navbar-collapse -->
           {% endblock %}
         </div>

--- a/web/js/search.js
+++ b/web/js/search.js
@@ -1,7 +1,9 @@
 $(document).on('data.app', function() {
+	// We only need to calculate the latest_cards once and not on every findMatches call.
+	var latest_cards = select_only_latest_cards(NRDB.data.cards.find());
+
 	function findMatches(q, cb) {
 		if(q.match(/^\w:/)) return;
-		var latestCards = select_only_latest_cards(NRDB.data.cards.find());
 		var regexp = new RegExp(q, 'i');
 		var matchingCards = _.filter(latestCards, function (card) {
 			return regexp.test(_.deburr(card.title).toLowerCase().trim());

--- a/web/js/search.js
+++ b/web/js/search.js
@@ -1,6 +1,5 @@
 $(document).on('data.app', function() {
-	// We only need to calculate the latest_cards once and not on every findMatches call.
-	var latest_cards = select_only_latest_cards(NRDB.data.cards.find());
+	var latestCards = select_only_latest_cards(NRDB.data.cards.find());
 
 	function findMatches(q, cb) {
 		if(q.match(/^\w:/)) return;
@@ -17,7 +16,7 @@ $(document).on('data.app', function() {
 		minLength: 2
 	}, {
 		name: 'cardnames',
-		display: function(card) { return card.title + ' (' + card.pack.name + ')'; },
+		display: function(card) { return card.title; },
 		source: findMatches
 	});
 });

--- a/web/js/topnav.js
+++ b/web/js/topnav.js
@@ -1,0 +1,54 @@
+/* global NRDB, Promise, _ */
+
+Promise.all([NRDB.data.promise, NRDB.ui.promise]).then(function() {
+	// TODO(plural): Find a better place for this and remove the duplicate definitions.
+	// This will filter matchingCards to only the latest version of each card, preserving the original order of matchingCards.
+	function select_only_latest_cards(matchingCards) {
+		var latestCardsByTitle = {};
+		for (var card of matchingCards) {
+			var latestCard = latestCardsByTitle[card.title];
+			if (!latestCard || card.code > latestCard.code) {
+				latestCardsByTitle[card.title] = card;
+			}
+		}
+		return matchingCards.filter(function(value, index, arr) {
+			return value.code == latestCardsByTitle[value.title].code;
+		});
+	}
+
+	// We only need to calculate the latest_cards once and not on every findMatches call.
+	var latest_cards = select_only_latest_cards(NRDB.data.cards.find());
+
+	function findMatches(q, cb) {
+		if (q.match(/^\w:/)) { return; }
+
+		var regexp = new RegExp(q, 'i');
+		var matchingCards = _.filter(latest_cards, function (card) {
+			return regexp.test(_.deburr(card.title).toLowerCase().trim());
+		});
+		cb(_.sortBy(matchingCards, 'title'));
+	}
+	$('#top_nav_card_search_menu').on('shown.bs.dropdown', function (element) {
+		$("#top_nav_card_search").focus();
+	});
+
+	$('#top_nav_card_search').typeahead({
+		hint: true,
+		highlight: true,
+		minLength: 2
+	}, {
+		display: function(card) { return card.title + ' (' + card.pack.name + ')'; },
+		source: findMatches
+	});
+	$('#top_nav_card_search').on('typeahead:selected typeahead:autocomplete', function(event, data) {
+		location.href=Routing.generate('cards_zoom', {card_code:data.code, _locale:NRDB.locale});
+	});
+
+$('#top_nav_card_search').keypress(function(event){
+                var keycode = (event.keyCode ? event.keyCode : event.which);
+                if(keycode == '13'){
+			console.log('enter....');
+			$('#top_nav_card_search_form').submit();
+                }
+            });
+});

--- a/web/js/topnav.js
+++ b/web/js/topnav.js
@@ -1,29 +1,13 @@
 /* global NRDB, Promise, _ */
 
 Promise.all([NRDB.data.promise, NRDB.ui.promise]).then(function() {
-	// TODO(plural): Find a better place for this and remove the duplicate definitions.
-	// This will filter matchingCards to only the latest version of each card, preserving the original order of matchingCards.
-	function select_only_latest_cards(matchingCards) {
-		var latestCardsByTitle = {};
-		for (var card of matchingCards) {
-			var latestCard = latestCardsByTitle[card.title];
-			if (!latestCard || card.code > latestCard.code) {
-				latestCardsByTitle[card.title] = card;
-			}
-		}
-		return matchingCards.filter(function(value, index, arr) {
-			return value.code == latestCardsByTitle[value.title].code;
-		});
-	}
-
-	// We only need to calculate the latest_cards once and not on every findMatches call.
-	var latest_cards = select_only_latest_cards(NRDB.data.cards.find());
+	var all_cards = NRDB.data.cards.find();
 
 	function findMatches(q, cb) {
 		if (q.match(/^\w:/)) { return; }
 
 		var regexp = new RegExp(q, 'i');
-		var matchingCards = _.filter(latest_cards, function (card) {
+		var matchingCards = _.filter(all_cards, function (card) {
 			return regexp.test(_.deburr(card.title).toLowerCase().trim());
 		});
 		cb(_.sortBy(matchingCards, 'title'));
@@ -44,11 +28,10 @@ Promise.all([NRDB.data.promise, NRDB.ui.promise]).then(function() {
 		location.href=Routing.generate('cards_zoom', {card_code:data.code, _locale:NRDB.locale});
 	});
 
-$('#top_nav_card_search').keypress(function(event){
-                var keycode = (event.keyCode ? event.keyCode : event.which);
-                if(keycode == '13'){
-			console.log('enter....');
+	$('#top_nav_card_search').keypress(function(event) {
+		var keycode = (event.keyCode ? event.keyCode : event.which);
+		if(keycode == '13'){
 			$('#top_nav_card_search_form').submit();
-                }
-            });
+		}
+	});
 });


### PR DESCRIPTION
This has a bunch of changes.  Sadly a bunch of duplication, but i'll tidy that up in a follow-up.

The top nav now has auto-completion, but it is in a drop down.  There is the same number of clicks right now, but i'm definitely looking for feedback there.

The card page needs to put the code for the card into the search box in order to get to the card you actually selected.  Otherwise cards whose names are substring matches for other cards will show the search results page, not the card you selected in the dropdown.

# Top Nav
![top-nav-search-1](https://user-images.githubusercontent.com/396562/71594932-6b184080-2aff-11ea-8730-2f68f51e2995.png)
![top-nav-search-2](https://user-images.githubusercontent.com/396562/71594934-6ce20400-2aff-11ea-86b9-4bcf47ec1cdc.png)
![top-nav-search-3](https://user-images.githubusercontent.com/396562/71594940-6eabc780-2aff-11ea-98ba-7055b1a48c2e.png)
![top-nav-search-4](https://user-images.githubusercontent.com/396562/71594957-753a3f00-2aff-11ea-80a8-8fb1572de1ff.png)

# Card Page
![card-page-autocomplete-1](https://user-images.githubusercontent.com/396562/71595003-a4e94700-2aff-11ea-97cb-cc7d65d4e242.png)
![card-page-autocomplete-2](https://user-images.githubusercontent.com/396562/71595004-a6b30a80-2aff-11ea-9f06-0cb0030293b5.png)
![card-page-autocomplete-3](https://user-images.githubusercontent.com/396562/71595006-a87cce00-2aff-11ea-820d-08cdf94f9972.png)


# Advanced Search Page
![advanced-search-autocomplete-2](https://user-images.githubusercontent.com/396562/71594990-8daa5980-2aff-11ea-9400-f6a10bd383e6.png)
![advanced-search-autocomplete-3](https://user-images.githubusercontent.com/396562/71594992-8f741d00-2aff-11ea-9639-97895cc89e13.png)
