### PR TITLE
Rename 'Spoilers' on the card search form to be 'Text only' 

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -26,7 +26,7 @@ class SearchController extends Controller
 
     const VIEW_OPTIONS = array(
         'list'    => 'a Checklist',
-        'text'    => 'a Spoiler',
+        'text'    => 'Text only',
         'full'    => 'Full Cards',
         'images'  => 'Images only',
         'rulings' => 'Rulings only',


### PR DESCRIPTION
This is just a tiny fix to make things more logical.

![spoilers-1](https://user-images.githubusercontent.com/396562/71595293-9e0f0400-2b00-11ea-8869-4900b3e89cbb.png)
![spoilers-2](https://user-images.githubusercontent.com/396562/71595295-9fd8c780-2b00-11ea-9524-12823e6e324c.png)
