### PR TITLE
Quick fix to decklist autocomplete and editing a deck description.

### DIFF
--- a/app/Resources/views/Decklist/decklist.html.twig
+++ b/app/Resources/views/Decklist/decklist.html.twig
@@ -371,7 +371,7 @@ NRDB.user.params.decklist_id = Decklist.id;
 							<div>
 								<small>Description Preview. Look <a href="http://daringfireball.net/projects/markdown/dingus">here</a> for a Markdown syntax reference.</small>
 							</div>
-							<div class="well text-muted" id="publish-deck-description-preview"></div>
+							<div class="well text-muted" id="edit-decklist-description-preview"></div>
 							<div class="form-group">
 								<label for="edit-decklist-tournament">Placed high in a tournament (Store Championship and better)</label>
 								<select class="form-control" name="tournament" id="edit-decklist-tournament">

--- a/app/Resources/views/Decklist/decklist.html.twig
+++ b/app/Resources/views/Decklist/decklist.html.twig
@@ -368,6 +368,10 @@ NRDB.user.params.decklist_id = Decklist.id;
 								<label for="edit-decklist-description">Description</label>
 								<textarea class="form-control" name="description" id="edit-decklist-description" maxlength="40000" rows="5" placeholder="Enter a brief explanation of the deck strategy and your significant choices">{{ decklist.rawdescription }}</textarea>
 							</div>
+							<div>
+								<small>Description Preview. Look <a href="http://daringfireball.net/projects/markdown/dingus">here</a> for a Markdown syntax reference.</small>
+							</div>
+							<div class="well text-muted" id="publish-deck-description-preview"></div>
 							<div class="form-group">
 								<label for="edit-decklist-tournament">Placed high in a tournament (Store Championship and better)</label>
 								<select class="form-control" name="tournament" id="edit-decklist-tournament">

--- a/web/js/deck.js
+++ b/web/js/deck.js
@@ -365,7 +365,7 @@ $(function() {
 			}));
 		},
 		template : function(value) {
-			return value.title;
+			return value.title + ' (' + value.pack.name + ')';
 		},
 		replace : function(value) {
 			return '[' + value.title + ']('

--- a/web/js/decklist.js
+++ b/web/js/decklist.js
@@ -373,10 +373,10 @@ function edit_form() {
     $('#editModal').modal('show');
 
 	var converter = new Markdown.Converter();
-	$('#publish-deck-description-preview').html(
+	$('#edit-decklist-description-preview').html(
 			converter.makeHtml($('#edit-decklist-description').val()));
 	$('#edit-decklist-description').on('keyup', function() {
-		$('#publish-deck-description-preview').html(
+		$('#edit-decklist-description-preview').html(
 				converter.makeHtml($('#edit-decklist-description').val()));
 	});
 

--- a/web/js/decklist.js
+++ b/web/js/decklist.js
@@ -116,7 +116,7 @@ function setup_comment_form() {
                 callback(result);
             },
             template: function (value) {
-                return value.title;
+                return value.title + ' (' + value.pack.name + ')';
             },
             replace: function (value) {
                 return '[' + value.title + ']('
@@ -371,6 +371,50 @@ function compare_form() {
 
 function edit_form() {
     $('#editModal').modal('show');
+
+	var converter = new Markdown.Converter();
+	$('#publish-deck-description-preview').html(
+			converter.makeHtml($('#edit-decklist-description').val()));
+	$('#edit-decklist-description').on('keyup', function() {
+		$('#publish-deck-description-preview').html(
+				converter.makeHtml($('#edit-decklist-description').val()));
+	});
+
+	$('#edit-decklist-description').textcomplete([{
+		match : /\B#([\-+\w]*)$/,
+		search : function(term, callback) {
+			var regexp = new RegExp('\\b' + term, 'i');
+			// In the Notes section, we want to allow completion for *all* cards regardless of side.
+			callback(NRDB.data.cards.find({
+				title : regexp
+			}));
+		},
+		template : function(value) {
+			return value.title + ' (' + value.pack.name + ')';
+		},
+		replace : function(value) {
+			return '[' + value.title + ']('
+					+ Routing.generate('cards_zoom', {card_code:value.code})
+					+ ')';
+		},
+		index : 1
+	}, {
+		match : /\$([\-+\w]*)$/,
+		search : function(term, callback) {
+			var regexp = new RegExp('^' + term);
+			callback($.grep(['credit', 'recurring-credit', 'click', 'link', 'trash', 'subroutine', 'mu', '1mu', '2mu', '3mu',
+				'anarch', 'criminal', 'shaper', 'haas-bioroid', 'weyland-consortium', 'jinteki', 'nbn'],
+				function(symbol) { return regexp.test(symbol); }
+			));
+		},
+		template : function(value) {
+			return value;
+		},
+		replace : function(value) {
+			return '<span class="icon icon-' + value + '"></span>';
+		},
+		index : 1
+	}]);
 }
 
 function delete_form() {

--- a/web/js/decks.js
+++ b/web/js/decks.js
@@ -466,7 +466,7 @@ function confirm_publish(deck) {
 						title: regexp
 						}));
 					},
-					template: function (value) { return value.title; },
+					template: function (value) { return value.title + ' (' + value.pack.name + ')'; },
 					replace: function (value) {
 						return '[' + value.title + ']('
 							+ Routing.generate('cards_zoom', {card_code: value.code})


### PR DESCRIPTION
Add pack names into the deck description auto-completion.
![Screenshot 2019-12-30 at 1 04 52 PM](https://user-images.githubusercontent.com/396562/71597381-7f147000-2b08-11ea-95cd-044ce9616ea3.png)

Add preview to the edit published deck description form.
tired:
![Screenshot 2019-12-30 at 1 06 18 PM](https://user-images.githubusercontent.com/396562/71597411-9bb0a800-2b08-11ea-8570-865439d286f1.png)
wired:
![Screenshot 2019-12-30 at 1 28 25 PM](https://user-images.githubusercontent.com/396562/71597422-a703d380-2b08-11ea-9c67-327a2d722f78.png)

