### PR TITLE
Properly update the collection filters when using the collection shortcuts

### DIFF
--- a/web/js/deck.js
+++ b/web/js/deck.js
@@ -189,18 +189,21 @@ function create_collection_tab(initialPackSelection) {
 		$('#pack_code').find(':checkbox').each(function() {
 			$(this).prop('checked', !(rotated_cycles[$(this).prop('name')] || rotated_packs[$(this).prop('name')]));
 		});
+		update_collection_packs();
 	});
 	$('#collection_all').on('click', function(event) {
 		event.preventDefault();
 		$('#pack_code').find(':checkbox').each(function(){
 			$(this).prop('checked', true);
 		});
+		update_collection_packs();
 	});
 	$('#collection_none').on('click', function(event) {
 		event.preventDefault();
 		$('#pack_code').find(':checkbox').each(function(){
 			$(this).prop('checked', false);
 		});
+		update_collection_packs();
 	});
 
 	var sets_in_deck = {};
@@ -519,9 +522,9 @@ function handle_header_click(event) {
 			Order > 0 ? '' : 'dropup');
 	refresh_collection();
 }
-function handle_input_change(event) {
-	var div = $(this).closest('.filter');
-	var columnName = div.attr('id');
+
+function update_collection_packs() {
+	var div = $('#pack_code')
 	var arr = [];
 	div.find("input[type=checkbox]").each(function(index, elt) {
 		var name = $(elt).attr('name');
@@ -530,16 +533,34 @@ function handle_input_change(event) {
 			arr.push(name);
 		}
 
-		if (columnName == "pack_code") {
-			var key = 'pack_code_' + name,
-				value = $(elt).prop('checked') ? "on" : "off";
-			localforage.setItem(key, value);
+		var key = 'pack_code_' + name, value = $(elt).prop('checked') ? "on" : "off";
+		localforage.setItem(key, value);
+	});
+	Filters['pack_code'] = arr;
+	FilterQuery = get_filter_query(Filters);
+	refresh_collection();
+}
+
+function handle_input_change(event) {
+	var div = $(this).closest('.filter');
+	var columnName = div.attr('id');
+	if (columnName == 'pack_code') {
+		update_collection_packs();
+		return;
+	}
+	var arr = [];
+	div.find("input[type=checkbox]").each(function(index, elt) {
+		var name = $(elt).attr('name');
+
+		if (name && $(elt).prop('checked')) {
+			arr.push(name);
 		}
 	});
 	Filters[columnName] = arr;
 	FilterQuery = get_filter_query(Filters);
 	refresh_collection();
 }
+
 function get_deck_content() {
 	return _.reduce(
 			NRDB.data.cards.find({indeck:{'$gt':0}}),


### PR DESCRIPTION
Sorry these didn't work well originally!

This fixes #417 

![Screenshot 2020-02-15 at 12 16 20 PM](https://user-images.githubusercontent.com/396562/74593074-53ccde00-4fed-11ea-9552-a178c4dc4cbb.png)
![Screenshot 2020-02-15 at 12 16 35 PM](https://user-images.githubusercontent.com/396562/74593075-562f3800-4fed-11ea-8f58-696949073696.png)
![Screenshot 2020-02-15 at 12 16 48 PM](https://user-images.githubusercontent.com/396562/74593076-57f8fb80-4fed-11ea-8d9c-327cb583d8df.png)
![Screenshot 2020-02-15 at 12 17 02 PM](https://user-images.githubusercontent.com/396562/74593078-59c2bf00-4fed-11ea-9923-ff81291beba2.png)
![Screenshot 2020-02-15 at 12 17 11 PM](https://user-images.githubusercontent.com/396562/74593080-5c251900-4fed-11ea-96bd-d35f8a789390.png)

There is more that could be done to tidy this up.  I think there are a couple of other deckbuilder bugs that probably share a similar root cause, but i'll look at those separately.