### PR TITLE
Bring back the paging controls on the search page.

### DIFF
--- a/app/Resources/views/Search/pagination.html.twig
+++ b/app/Resources/views/Search/pagination.html.twig
@@ -23,3 +23,21 @@
 </ul>
 </div>
 </div>
+<div class="row">
+<div class="col-sm-2">
+</div>
+<div class="col-sm-8 text-center">
+<ul class="pagination">
+  {{ first|raw }}
+  {% if ellipsisbefore %}<li class="disabled"><a href="#">...</a></li>{% endif %}
+  {{ prev|raw }}
+  {{ current|raw }}
+  {{ next|raw }}
+  {% if ellipsisafter %}<li class="disabled"><a href="#">...</a></li>{% endif %}
+  {{ last|raw }}
+</ul>
+</div>
+<div class="col-sm-2 text-right">
+	<p style="margin:27px 0">{{ count }} cards</p>
+</div>
+</div>


### PR DESCRIPTION
Fixes #408 

This could use some layout love, but bringing back the functionality is the most important thing.

![penguin linux test_8080_app_dev php_en_set_hap_full_set_2](https://user-images.githubusercontent.com/396562/74673884-c668c580-5175-11ea-890e-50aeb74f9ad9.png)
![Screenshot 2020-02-17 at 11 07 54 AM](https://user-images.githubusercontent.com/396562/74673888-c8328900-5175-11ea-96e4-97e55a51f55e.png)
