### PR TITLE
Add rotated and removed icons on the deck identity selection page.

### DIFF
--- a/app/Resources/views/Builder/initbuild.html.twig
+++ b/app/Resources/views/Builder/initbuild.html.twig
@@ -4,11 +4,11 @@
 
 <script type="text/javascript">
 $(function() {
-	$('.list-group').on('mouseenter touchstart', 'a', function(event) {
-		var card_code = $(this).data('code');
-		var card = NRDB.data.cards.findById(card_code);
-		$('#cardimg').prop('src', card.imageUrl);
-	});
+    $('.list-group').on('mouseenter touchstart', 'a', function(event) {
+        var card_code = $(this).data('code');
+        var card = NRDB.data.cards.findById(card_code);
+        $('#cardimg').prop('src', card.imageUrl);
+    });
     $(window).scroll(function() {
         var scrollingDiv = $("#initIdentity");
         if(!scrollingDiv.is(':visible')) return;
@@ -32,13 +32,15 @@ $(function() {
 <div class="col-sm-8">
 <div class="panel panel-default">
   <!-- Default panel contents -->
-  <div class="panel-heading"><b>Choose your identity</b></div>
+  <div class="panel-heading"><b>Choose your identity</b> <em>(🔄  rotated from current play, 🚫  banned by  current MWL)</em></div>
   <!-- List group -->
 <div class="list-group">
 {% for identity in identities %}
 <a href="{{ path('deck_initbuild', {card_code:identity.code}) }}" class="list-group-item" data-code="{{ identity.code }}">
-	<span class="icon icon-{{ identity.faction.code }} {{ identity.faction.code }}"></span>
-	<span>{{ identity.title(app.request.locale) }}</span> <span class="small">({{ identity.pack.name }})</span>
+    <span class="icon icon-{{ identity.faction.code }} {{ identity.faction.code }}"></span>
+    <span>{{ identity.title(app.request.locale) }}</span> <span class="small">({{ identity.pack.name }})</span>
+    <span>{% if identity.pack.cycle.rotated %}🔄{% endif %}</span>
+    <span>{% if identity.code in banned_cards|keys %}🚫{% endif %}</span>
 </a>
 {% endfor %}
 </div>

--- a/app/Resources/views/Builder/initbuild.html.twig
+++ b/app/Resources/views/Builder/initbuild.html.twig
@@ -32,7 +32,7 @@ $(function() {
 <div class="col-sm-8">
 <div class="panel panel-default">
   <!-- Default panel contents -->
-  <div class="panel-heading"><b>Choose your identity</b> <em>(🔄  rotated from current play, 🚫  banned by  current MWL)</em></div>
+  <div class="panel-heading"><b>Choose your identity</b> <span class="small">(🔄  rotated card, 🚫  banned card)</span></div>
   <!-- List group -->
 <div class="list-group">
 {% for identity in identities %}

--- a/app/Resources/views/Builder/initbuild.html.twig
+++ b/app/Resources/views/Builder/initbuild.html.twig
@@ -32,15 +32,15 @@ $(function() {
 <div class="col-sm-8">
 <div class="panel panel-default">
   <!-- Default panel contents -->
-  <div class="panel-heading"><b>Choose your identity</b> <span class="small">(🔄  rotated card, 🚫  banned card)</span></div>
+  <div class="panel-heading"><b>Choose your identity</b> <span>(🔄  rotated card, 🚫  banned card)</span></div>
   <!-- List group -->
 <div class="list-group">
 {% for identity in identities %}
 <a href="{{ path('deck_initbuild', {card_code:identity.code}) }}" class="list-group-item" data-code="{{ identity.code }}">
     <span class="icon icon-{{ identity.faction.code }} {{ identity.faction.code }}"></span>
     <span>{{ identity.title(app.request.locale) }}</span> <span class="small">({{ identity.pack.name }})</span>
-    <span>{% if identity.pack.cycle.rotated %}🔄{% endif %}</span>
-    <span>{% if identity.code in banned_cards|keys %}🚫{% endif %}</span>
+    {% if identity.pack.cycle.rotated %}<span>🔄</span>{% endif %}
+    {% if identity.code in banned_cards|keys %}<span>🚫</span>{% endif %}
 </a>
 {% endfor %}
 </div>


### PR DESCRIPTION
I don't always remember what has been banned and rotated, so i wanted to see that on the ID selection page.

Uses the currently selected MWL and the latest rotation information.

*Corp selection*
![id-selection-corp](https://user-images.githubusercontent.com/396562/78610302-2c92d000-782a-11ea-8974-2f56aec12c7e.png)

*Runner selection*
![id-selection-runner](https://user-images.githubusercontent.com/396562/78610311-2f8dc080-782a-11ea-91bd-8cb01ae30cf1.png)
