### PR TITLE
Add search operator to specify rotations.

### DIFF
--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -38,6 +38,7 @@
             <li><code>h</code> &ndash; trash cost</li>
             <li><code>r</code> &ndash; release date</li>
             <li><code>u</code> &ndash; unique</li>
+            <li><code>z</code> &ndash; rotation</li>
           </ul>
         </li>
         <li>an <b>operator</b> is either:
@@ -49,6 +50,7 @@
           </ul>
         </li>
         <li><b>Special case</b> <code>r</code> (release date) uses only the operators <code>&lt;</code> (inclusive) and <code>&gt;</code> (exclusive) and only understands the arguments <code>now</code> or a date YYYY-MM-DD</li>
+        <li><b>Rotation</b> <code>z</code> Rotation takes 2 different options for the current rotation: <code>current</code> or <code>latest</code>.  Rotation can also specify a specific rotation.  Valid specific rotation options are <code>rotation-2017</code>, <code>rotation-2017</code>, or <code>rotation-2017</code>.
   </ul>
 
   <h2>Search examples</h2>
@@ -63,6 +65,7 @@
     <li><code>r&lt;2013-01-01</code> searches for all cards released up to Jan 1, 2013</li>
     <li><code>d:r|c</code> searches for all Runner and Corp cards</li>
     <li><code>x:&#34;the Corp loses 1[credit]&#34;</code> returns Amina, Corporate &#34;Grant&#34;, and Lamprey</li>
+    <li><code>d:corp z:current</code> returns all corp cards in the cycles valid for the latest rotation</li>
   </ul>
 </div>
 {% endblock %}

--- a/app/Resources/views/Search/searchtooltip.html.twig
+++ b/app/Resources/views/Search/searchtooltip.html.twig
@@ -15,6 +15,7 @@ Search filters:
    i - illustrator (word or &#34;phrase with spaces&#34;)
    u - unique (0 for non-unique, 1 for unique)
    y - quantity in pack (number)
+   z - rotation (one of: current, latest, rotation-2017, rotation-2018, rotation-2019)
 
 Filter operators:
    : - include or is equal to the condition

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -8,6 +8,8 @@ use AppBundle\Entity\Mwl;
 use AppBundle\Entity\Pack;
 use AppBundle\Entity\Review;
 use AppBundle\Entity\Ruling;
+use AppBundle\Entity\Rotation;
+use AppBundle\Service\RotationService;
 use AppBundle\Repository\PackRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Asset\Packages;
@@ -166,7 +168,6 @@ class CardsData
 
         $qb2 = null;
         $qb3 = null;
-
         $clauses = [];
         $parameters = [];
 
@@ -577,6 +578,22 @@ class CardsData
                         $clauses[] = "(c.uniqueness = 1)";
                     } else {
                         $clauses[] = "(c.uniqueness = 0)";
+                    }
+                    $i++;
+                    break;
+                case 'z': // rotation
+                    // Instantiate the service only when its needed.
+                    $rotationservice = new RotationService($this->entityManager);
+				    $rotation = null;
+                    if ($condition[0] == "current" || $condition[0] == "latest") {
+                        $rotation = $rotationservice->findCurrentRotation();
+                    } else {
+						$rotation = $rotationservice->findRotationByCode($condition[0]);
+                    }
+                    if ($rotation) {
+                        // Add the valid cycles for the requested rotation and add them to the WHERE clause for the query.
+                        $cycles = "'" . implode("','", $rotation->normalize()["cycles"]) ."'";
+                        $clauses[] = "(y.code in ($cycles))";
                     }
                     $i++;
                     break;

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -584,16 +584,21 @@ class CardsData
                 case 'z': // rotation
                     // Instantiate the service only when its needed.
                     $rotationservice = new RotationService($this->entityManager);
-				    $rotation = null;
+                    $rotation = null;
                     if ($condition[0] == "current" || $condition[0] == "latest") {
                         $rotation = $rotationservice->findCurrentRotation();
                     } else {
-						$rotation = $rotationservice->findRotationByCode($condition[0]);
+                        $rotation = $rotationservice->findRotationByCode($condition[0]);
                     }
                     if ($rotation) {
                         // Add the valid cycles for the requested rotation and add them to the WHERE clause for the query.
-                        $cycles = "'" . implode("','", $rotation->normalize()["cycles"]) ."'";
-                        $clauses[] = "(y.code in ($cycles))";
+                        $cycles = $rotation->normalize()["cycles"];
+                        $placeholders = array();
+                        foreach($cycles as $cycle) {
+                        array_push($placeholders, "?$i");
+                            $parameters[$i++] = $cycle;
+                        }
+                        $clauses[] = "(y.code in (" . implode(", ", $placeholders) . "))";
                     }
                     $i++;
                     break;

--- a/src/AppBundle/Service/RotationService.php
+++ b/src/AppBundle/Service/RotationService.php
@@ -22,6 +22,22 @@ class RotationService
         $this->entityManager = $entityManager;
     }
 
+    /**
+     * Returns the first entry of the descending sorted rotations
+     * @return Rotation current Rotation
+     */
+    public function findCurrentRotation()
+    {
+        $rotation = $this->entityManager->getRepository(Rotation::class)->findOneBy([], ['dateStart' => 'DESC']);
+
+        // There should always be a rotation available.
+        if (!$rotation) {
+            throw new \Exception("No current rotation found", 1);
+        }
+
+        return $rotation;
+    }
+
     public function findCompatibleRotation(Decklist $decklist)
     {
         $rotations = $this->entityManager->getRepository(Rotation::class)->findBy([], ['dateStart' => 'DESC']);
@@ -51,4 +67,14 @@ class RotationService
             return $cycle->getCode();
         }, $rotation->getCycles()->toArray()))) === 0;
     }
+
+    /**
+     * @param string $code
+     * @return Rotation rotation with the matching code or null if not found.
+     */
+    public function findRotationByCode(string $code)
+    {
+        return $this->entityManager->getRepository(Rotation::class)->findOneBy(['code' => $code]);
+    }
+
 }


### PR DESCRIPTION
This is based off of https://github.com/Alsciende/netrunnerdb/pull/414 by @opaldes.

I incorporated my feedback on the original PR and updated the syntax pages as well.

I picked this up because we haven't heard back for a while.

Partially addresses #309 

(note that we already de-dupe to the latest card when multiples are present, so yo don't see some of the cards in the original core set)
![z-op-current-data](https://user-images.githubusercontent.com/396562/78701435-a8455900-78cc-11ea-8554-c3a4af6f7443.png)

# Runner cards, 2017 rotation
![z-op-runner-2017](https://user-images.githubusercontent.com/396562/78701568-dd51ab80-78cc-11ea-828b-9c815fdb87e5.png)

# Runner cards, 2018 rotation
![z-op-runner-2018](https://user-images.githubusercontent.com/396562/78701573-e04c9c00-78cc-11ea-8fa1-5f3282a21fdd.png)

# Runner cards, 2019 rotation
![z-op-runner-2019](https://user-images.githubusercontent.com/396562/78701581-e2aef600-78cc-11ea-89b7-762bba88dbee.png)
