### PR TITLE
Fix banlist for decklist search.

### DIFF
--- a/src/AppBundle/Service/DecklistManager.php
+++ b/src/AppBundle/Service/DecklistManager.php
@@ -750,7 +750,7 @@ class DecklistManager
         if (!empty($mwl_code)) {
             $wheres[] = 'exists(select * from legality join mwl on legality.mwl_id=mwl.id where legality.decklist_id=d.id and mwl.code=? and legality.is_legal=1)';
             $params[] = $mwl_code;
-            $types[] = \PDO::PARAM_INT;
+            $types[] = \PDO::PARAM_STR;
         }
         if (!empty($rotation_id)) {
             $wheres[] = 'd.rotation_id=?';


### PR DESCRIPTION
The ban list drop down has the mwl code (string form like standard-ban-list-20-06) and the query had the right SQL, but the type for the parameter was set to INT, causing the param to be dropped.  I guess it's nice that this just silently failed instead of crashing, but it definitely wasn't working.  :)