### PR TITLE
Allow importer to add cycles to rotations.

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -573,6 +573,25 @@ class ImportStdCommand extends ContainerAwareCommand
             return $entity;
         }
 
+        // Special handling for rotation.
+        // The code above already catches new rotation entries, but if the only
+        // difference is in the cycles already in the db for an existing entry,
+        // we need to check that manually.  If those are the same, just let the
+        // existing handling do its work.
+        if ($entityName === 'AppBundle\Entity\Rotation') {
+            $json_cycles = $data['cycles'];
+            sort($json_cycles);
+            $db_cycles = array();
+            foreach ($entity->GetCycles() as $c) {
+                array_push($db_cycles, $c->GetCode());
+            }
+            sort($db_cycles);
+            if ($json_cycles != $db_cycles) {
+                $this->output->writeln("Cycles don't match for rotation <info>" . $entity->GetName() . "</info>, so updating it.");
+                return $entity;
+            }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
This wasn't previously working because cycles weren't part of the
object comparison done by the importer.

Thanks to whoever discovered Salvaged Memories wasn't showing up
in searches with z:current!