### PR TITLE
Fix variable scoping issue triggered when no cards are found.

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -405,6 +405,8 @@ class SearchController extends Controller
 
         $cardsData->validateConditions($conditions);
 
+        $card = null;
+
         // reconstruction of the correct search string for display
         $q = $cardsData->buildQueryFromConditions($conditions);
         $rows = $cardsData->get_search_rows($conditions, $sort, $locale);
@@ -439,7 +441,6 @@ class SearchController extends Controller
             }
             $last = $first + $nb_per_page;
 
-            $card = null;
             $versions = null;
 
             if ($view == "zoom") {


### PR DESCRIPTION
This is swallowed in prod and shows a "Your query didn't match any
card." message, but in dev, there is a stack trace.