### PR TITLE
Only return rotations that are in effect.

### DIFF
--- a/src/AppBundle/Service/RotationService.php
+++ b/src/AppBundle/Service/RotationService.php
@@ -23,12 +23,17 @@ class RotationService
     }
 
     /**
-     * Returns the first entry of the descending sorted rotations
+     * Returns the first entry of the descending sorted rotations that is active by date_start.
      * @return Rotation current Rotation
      */
     public function findCurrentRotation()
     {
-        $rotation = $this->entityManager->getRepository(Rotation::class)->findOneBy([], ['dateStart' => 'DESC']);
+        $rotation = $this->entityManager->getRepository(Rotation::class)->createQueryBuilder('r')
+            ->where('r.dateStart <= CURRENT_DATE()')
+            ->orderBy('r.dateStart', 'DESC')
+            ->getQuery()
+            ->setMaxResults(1)
+            ->getOneOrNullResult();
 
         // There should always be a rotation available.
         if (!$rotation) {


### PR DESCRIPTION
tested locally by searching for "z:current reina"

It fails with the 2021 rotation data in place, but with the patch, reina is returned.

This will future proof subsequent rotation, but hopefully we'll be on nrdb v2 by then!!!