### PR TITLE
Tidy banlist & rotation indicators on the card page

### DIFF
--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -122,6 +122,34 @@
                     <thead>
                         <tr>
                             <th>
+                              <span>Standard Play Legality</span> <a id="mwl-history" href="" onClick="
+let entries = $.find('tr.card-mwl-inactive');  entries.forEach(x => x.style.display = (x.style.display == 'table-row' ? 'none' : 'table-row'));
+let l = $('#mwl-history'); l.html(l.text() == '(show all)' ? '(show only latest)' : '(show all)');
+return false;">(show all)</a>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                       {% for mwl_info in card.mwl_info %}
+                       <tr class="card-mwl-{% if mwl_info.active %}active{% else %}inactive{% endif %}" style="display:{% if mwl_info.active %}table-row{% else %}none{% endif %}">
+                            <td>
+                              {% if mwl_info.no_effect %}<span title="No restrictions">✅</span>{% endif %}
+                              {% if mwl_info.is_restricted == true %}<span title="Restricted">🦄{% endif %}
+                              {% if mwl_info.deck_limit is not null and mwl_info.deck_limit == 0 %}<span title="Banned">🚫</span>{% endif %}
+                              {% if mwl_info.universal_faction_cost == 1 %}<span title="1 additional Universal Influence">1️⃣</span>{% endif %}
+                              {% if mwl_info.universal_faction_cost == 3 %}<span title="3 additional Universal Influence">3️⃣</span>{% endif %}
+                              {{ mwl_info.mwl_name }}{% if mwl_info.active %} (active) {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            <div class="panel-body">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>
                                 <span>Printings</span>
                             </th>
                         </tr>
@@ -139,31 +167,6 @@
                     </tbody>
                 </table>
             </div>
-        </div>
-    </div>
-</div>
-
-<div class="row">
-    <div class="col-md-12 MWL Entries" style="margin-top:2em">
-        <div style="ine-height:34px" class="mwl-entries-header">
-            <span style="font-size:24px">Ban List Entries</span>
-            {% if card.mwl_info|length %}
-            <ul class="mwl-entries-list">
-                {% for mwl_info in card.mwl_info %}
-                {% if mwl_info.is_restricted == true %}
-                <li>{{ mwl_info.mwl_name }}{% if mwl_info.active %} (active){% endif %}: Restricted</li>
-                {% endif %}
-                {% if mwl_info.deck_limit is not null and mwl_info.deck_limit == 0 %}
-                <li>{{ mwl_info.mwl_name }}{% if mwl_info.active %} (active){% endif %}: Banned</li>
-                {% endif %}
-                {% if mwl_info.universal_faction_cost > 0 %}
-                <li>{{ mwl_info.mwl_name }}{% if mwl_info.active %} (active){% endif %}: {{ mwl_info.universal_faction_cost }} Universal Influence</li>
-                {% endif %}
-                {% endfor %}
-            </ul>
-            {% else %}
-            <p><i>No Ban List Entries for this card.</i></p>
-            {% endif %}
         </div>
     </div>
 </div>

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -122,16 +122,49 @@
                     <thead>
                         <tr>
                             <th>
-                              <span>Standard Play Legality</span> <a id="mwl-history" href="" onClick="
+{% set is_ineligible = false %}
+{% set all_versions_rotated = true %}
+{% for version in card.versions %}
+  {% if (version.cycle_code == "draft") or (version.cycle_code == "terminal-directive") %}
+    {% set is_ineligible = true %}
+  {% endif %}
+  {% if currentRotationCycles[version.cycle_code] is defined %}
+    {% set all_versions_rotated = false %}
+  {% endif %}
+{% endfor %}
+{% if is_ineligible %}
+<span title="Draft and Campaign Cards are not Standard Legal">🚫</span>
+{% else %}
+  {% if all_versions_rotated %}
+    <span title="Card is Rotated">🔄</span>
+  {% else %}
+    <span title="Card is in the Standard Card Pool">✅</a>
+  {% endif %}
+{% endif %}
+: Standard Card Pool
+                          </th>
+                        </tr>
+                        <tr>
+                            <th>
+                       {% for mwl_info in card.mwl_info %}
+                         {% if mwl_info.active %}
+                              {% if mwl_info.no_effect %}<span title="No restrictions">✅</span>{% endif %}
+                              {% if mwl_info.is_restricted == true %}<span title="Restricted">🦄{% endif %}
+                              {% if mwl_info.deck_limit is not null and mwl_info.deck_limit == 0 %}<span title="Banned">🚫</span>{% endif %}
+                              {% if mwl_info.universal_faction_cost == 1 %}<span title="1 additional Universal Influence">1️⃣</span>{% endif %}
+                              {% if mwl_info.universal_faction_cost == 3 %}<span title="3 additional Universal Influence">3️⃣</span>{% endif %}
+                          {% endif %}
+                        {% endfor %} : Standard Ban List
+						<a id="mwl-history" href="" onClick="
 let entries = $.find('tr.card-mwl-inactive');  entries.forEach(x => x.style.display = (x.style.display == 'table-row' ? 'none' : 'table-row'));
-let l = $('#mwl-history'); l.html(l.text() == '(show all)' ? '(show only latest)' : '(show all)');
-return false;">(show all)</a>
+let l = $('#mwl-history'); l.html(l.text() == '(show history)' ? '(show only latest)' : '(show history)');
+return false;">(show history)</a>
                             </th>
                         </tr>
                     </thead>
                     <tbody>
                        {% for mwl_info in card.mwl_info %}
-                       <tr class="card-mwl-{% if mwl_info.active %}active{% else %}inactive{% endif %}" style="display:{% if mwl_info.active %}table-row{% else %}none{% endif %}">
+                       <tr class="card-mwl-inactive" style="display:none">
                             <td>
                               {% if mwl_info.no_effect %}<span title="No restrictions">✅</span>{% endif %}
                               {% if mwl_info.is_restricted == true %}<span title="Restricted">🦄{% endif %}

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -125,7 +125,7 @@
 {% set is_ineligible = false %}
 {% set all_versions_rotated = true %}
 {% for version in card.versions %}
-  {% if (version.cycle_code == "draft") or (version.cycle_code == "terminal-directive") %}
+  {% if (version.cycle_code == "draft") or (version.pack_code == "tdc") %}
     {% set is_ineligible = true %}
   {% endif %}
   {% if currentRotationCycles[version.cycle_code] is defined %}

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -121,57 +121,23 @@
                 <table>
                     <thead>
                         <tr>
-                            <th>
-{% set is_ineligible = false %}
-{% set all_versions_rotated = true %}
-{% for version in card.versions %}
-  {% if (version.cycle_code == "draft") or (version.pack_code == "tdc") %}
-    {% set is_ineligible = true %}
-  {% endif %}
-  {% if currentRotationCycles[version.cycle_code] is defined %}
-    {% set all_versions_rotated = false %}
-  {% endif %}
-{% endfor %}
-{% if is_ineligible %}
-<span title="Draft and Campaign Cards are not Standard Legal">🚫</span>
-{% else %}
-  {% if all_versions_rotated %}
-    <span title="Card is Rotated">🔄</span>
-  {% else %}
-    <span title="Card is in the Standard Card Pool">✅</a>
-  {% endif %}
-{% endif %}
-: Standard Card Pool
-                          </th>
+                            <th class="legality-{{ card.standard_legality }}"> Standard Card Pool</th>
                         </tr>
                         <tr>
                             <th>
-                       {% for mwl_info in card.mwl_info %}
-                         {% if mwl_info.active %}
-                              {% if mwl_info.no_effect %}<span title="No restrictions">✅</span>{% endif %}
-                              {% if mwl_info.is_restricted == true %}<span title="Restricted">🦄{% endif %}
-                              {% if mwl_info.deck_limit is not null and mwl_info.deck_limit == 0 %}<span title="Banned">🚫</span>{% endif %}
-                              {% if mwl_info.universal_faction_cost == 1 %}<span title="1 additional Universal Influence">1️⃣</span>{% endif %}
-                              {% if mwl_info.universal_faction_cost == 3 %}<span title="3 additional Universal Influence">3️⃣</span>{% endif %}
-                          {% endif %}
-                        {% endfor %} : Standard Ban List
-						<a id="mwl-history" href="" onClick="
-let entries = $.find('tr.card-mwl-inactive');  entries.forEach(x => x.style.display = (x.style.display == 'table-row' ? 'none' : 'table-row'));
-let l = $('#mwl-history'); l.html(l.text() == '(show history)' ? '(show only latest)' : '(show history)');
-return false;">(show history)</a>
+                                <span
+                                    {% for mwl_info in card.mwl_info %}
+                                       {% if mwl_info.active %}class="legality-{{ mwl_info.legality }}"{% endif %}
+                                    {% endfor %}> Standard Ban List<span>
+                                    <a id="mwl-history" href="" onClick="let entries = $.find('tr.card-mwl-inactive'); entries.forEach(x => x.style.display = (x.style.display == 'table-row' ? 'none' : 'table-row')); let l = $('#mwl-history'); l.html(l.text() == '(show history)' ? '(show only latest)' : '(show history)'); return false;">(show history)</a>
                             </th>
                         </tr>
                     </thead>
                     <tbody>
-                       {% for mwl_info in card.mwl_info %}
-                       <tr class="card-mwl-inactive" style="display:none">
-                            <td>
-                              {% if mwl_info.no_effect %}<span title="No restrictions">✅</span>{% endif %}
-                              {% if mwl_info.is_restricted == true %}<span title="Restricted">🦄{% endif %}
-                              {% if mwl_info.deck_limit is not null and mwl_info.deck_limit == 0 %}<span title="Banned">🚫</span>{% endif %}
-                              {% if mwl_info.universal_faction_cost == 1 %}<span title="1 additional Universal Influence">1️⃣</span>{% endif %}
-                              {% if mwl_info.universal_faction_cost == 3 %}<span title="3 additional Universal Influence">3️⃣</span>{% endif %}
-                              {{ mwl_info.mwl_name }}{% if mwl_info.active %} (active) {% endif %}
+                        {% for mwl_info in card.mwl_info %}
+                        <tr class="card-mwl-inactive" style="display:none">
+                            <td class="legality-{{ mwl_info.legality }}">
+                                {{ mwl_info.mwl_name }}{% if mwl_info.active %} (active) {% endif %}
                             </td>
                         </tr>
                         {% endfor %}

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -56,7 +56,7 @@ class BuilderController extends Controller
         $banned_cards = array();
         foreach ($identities as $id) {
             $i = $cardsData->get_mwl_info([$id]);
-            if (count($i) > 0 && $i[array_keys($i)[0]]['active']) {
+            if (count($i) > 0 && $i[array_keys($i)[0]]['active'] && $i[array_keys($i)[0]]['deck_limit'] == 0) {
                 $banned_cards[$id->getCode()] = true;
             }
          }

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -56,7 +56,7 @@ class BuilderController extends Controller
         $banned_cards = array();
         foreach ($identities as $id) {
             $i = $cardsData->get_mwl_info([$id]);
-            if (count($i) > 0 && $i[0]['active']) {
+            if (count($i) > 0 && $i[array_keys($i)[0]]['active']) {
                 $banned_cards[$id->getCode()] = true;
             }
          }

--- a/src/AppBundle/Controller/FactionController.php
+++ b/src/AppBundle/Controller/FactionController.php
@@ -83,8 +83,9 @@ class FactionController extends Controller
                 }
 
                 $identity = $cardsData->select_only_latest_cards($identities);
+
                 $i = $cardsData->get_mwl_info([$identity[0]]);
-                if (count($i) > 0 && $i[0]['active']) {
+                if (count($i) > 0 && $i[array_keys($i)[0]]['active']) {
                     $banned_cards[$identity[0]->getCode()] = true;
                 }
 

--- a/src/AppBundle/Controller/FactionController.php
+++ b/src/AppBundle/Controller/FactionController.php
@@ -85,7 +85,7 @@ class FactionController extends Controller
                 $identity = $cardsData->select_only_latest_cards($identities);
 
                 $i = $cardsData->get_mwl_info([$identity[0]]);
-                if (count($i) > 0 && $i[array_keys($i)[0]]['active']) {
+                if (count($i) > 0 && $i[array_keys($i)[0]]['active'] && $i[array_keys($i)[0]]['deck_limit'] == 0) {
                     $banned_cards[$identity[0]->getCode()] = true;
                 }
 

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\Cycle;
 use AppBundle\Entity\Pack;
 use AppBundle\Entity\Type;
 use AppBundle\Service\CardsData;
+use AppBundle\Service\RotationService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -126,14 +127,14 @@ class SearchController extends Controller
         return $this->forward(
             'AppBundle:Search:display',
             [
-                '_route'        => $request->attributes->get('_route'),
-                '_route_params' => $request->attributes->get('_route_params'),
-                'q'             => $card->getCode(),
-                'view'          => 'card',
-                'sort'          => 'set',
-                'title'         => $card->getTitle(),
-                'meta'          => $meta,
-                'locale'        => $request->getLocale(),
+                '_route'           => $request->attributes->get('_route'),
+                '_route_params'    => $request->attributes->get('_route_params'),
+                'q'                => $card->getCode(),
+                'view'             => 'card',
+                'sort'             => 'set',
+                'title'            => $card->getTitle(),
+                'meta'             => $meta,
+                'locale'           => $request->getLocale(),
             ]
         );
     }
@@ -538,8 +539,15 @@ class SearchController extends Controller
             $title = $q;
         }
 
+		$currentRotationCycles = [];
+
         if ($view == "zoom") {
             $card = $cards[0];
+			$rotationService = new RotationService($entityManager);
+			$currentRotation = $rotationService->findCurrentRotation();
+			foreach($currentRotation->getCycles()->toArray() as $cycle) {
+				$currentRotationCycles[$cycle->getCode()] = true;
+			}
         }
 
         // attention si $s="short", $cards est un tableau à 2 niveaux au lieu de 1 seul
@@ -555,6 +563,7 @@ class SearchController extends Controller
             "pagetitle"       => $title,
             "metadescription" => $meta,
             "locales"         => $locales,
+            "currentRotationCycles" => $currentRotationCycles,
         ], $response);
     }
 

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -879,23 +879,33 @@ class CardsData
                     $deck_limit = $card_mwl['deck_limit'] ?? null;
                     // Ceux-ci signifient la même chose
                     $universal_faction_cost = $card_mwl['universal_faction_cost'] ?? $card_mwl['global_penalty'] ?? 0;
+                    $legality = 'legal';
+                    if ($is_restricted) {
+                       $legality = 'restricted';
+                    } elseif (!is_null($deck_limit) && $deck_limit == 0) {
+                        $legality = 'banned';
+                    } elseif ($universal_faction_cost == 1) {
+                        $legality = '1-inf';
+                    } elseif ($universal_faction_cost == 3) {
+                        $legality = '3-inf';
+                    }
                     $response[$mwl->getName()] = [
                         'mwl_name'               => $mwl->getName(),
                         'active'                 => $mwl->getActive(),
-                        'no_effect'              => false,
                         'is_restricted'          => $is_restricted,
                         'deck_limit'             => $deck_limit,
                         'universal_faction_cost' => $universal_faction_cost,
+                        'legality'               => $legality,
                     ];
                   } else {
-                    // Ensure that there is an active MWL entry for each card to make it as easy to determine if a card is unaffected by the current ban list.
+                    // Ensure that every card has MWL status for every MWL, not just the ones that specify it directly.
                     $response[$mwl->getName()] = [
                         'mwl_name'               => $mwl->getName(),
                         'active'                 => $mwl->getActive(),
-                        'no_effect'              => true,
                         'is_restricted'          => false,
-                        'deck_limit'             => 99, // for the callers of get_mwl_info, anything > 0 is good enough.
+                        'deck_limit'             => null,
                         'universal_faction_cost' => 0,
+                        'legality'               => 'legal',
                     ];
                 }
             }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -879,12 +879,23 @@ class CardsData
                     $deck_limit = $card_mwl['deck_limit'] ?? null;
                     // Ceux-ci signifient la même chose
                     $universal_faction_cost = $card_mwl['universal_faction_cost'] ?? $card_mwl['global_penalty'] ?? 0;
-                    $response[] = [
+                    $response[$mwl->getName()] = [
                         'mwl_name'               => $mwl->getName(),
                         'active'                 => $mwl->getActive(),
+                        'no_effect'              => false,
                         'is_restricted'          => $is_restricted,
                         'deck_limit'             => $deck_limit,
                         'universal_faction_cost' => $universal_faction_cost,
+                    ];
+                  } else {
+                    // Ensure that there is an active MWL entry for each card to make it as easy to determine if a card is unaffected by the current ban list.
+                    $response[$mwl->getName()] = [
+                        'mwl_name'               => $mwl->getName(),
+                        'active'                 => $mwl->getActive(),
+                        'no_effect'              => true,
+                        'is_restricted'          => false,
+                        'deck_limit'             => null,
+                        'universal_faction_cost' => 0,
                     ];
                 }
             }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -894,7 +894,7 @@ class CardsData
                         'active'                 => $mwl->getActive(),
                         'no_effect'              => true,
                         'is_restricted'          => false,
-                        'deck_limit'             => null,
+                        'deck_limit'             => 99, // for the callers of get_mwl_info, anything > 0 is good enough.
                         'universal_faction_cost' => 0,
                     ];
                 }

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -556,6 +556,26 @@ ul.rulings-list blockquote {
   padding: 0 2px;
 }
 
+/* Card legality indicators */
+.legality-banned:before {
+  content: "🚫";
+}
+.legality-legal:before {
+  content: "✅";
+}
+.legality-rotated:before {
+  content: "🔄";
+}
+.legality-restricted:before {
+  content: "🦄";
+}
+.legality-1-inf:before {
+  content: "1️⃣";
+}
+.legality-3-inf:before {
+  content: "3️⃣";
+}
+
 /*** screen reader fallback ***/
 .icon-fallback {
   border: 0;


### PR DESCRIPTION
Building on noah's awesome updates to the card page, add rotation (standard cardpool) and current standard banlist legality to the right column box.

Addresses #214  and #448 .

 
Hide banlist history unless the user asks for it.

Zer0 current:
![Screenshot 2021-03-12 at 9 22 23 AM](https://user-images.githubusercontent.com/396562/110960595-86422b00-8314-11eb-9cf6-9b092d93533d.png)


New Zer0 (default & expanded)
![Screenshot 2021-03-12 at 9 20 14 AM](https://user-images.githubusercontent.com/396562/110960435-5f83f480-8314-11eb-8f69-9e5062feb91c.png)
![Screenshot 2021-03-12 at 9 20 28 AM](https://user-images.githubusercontent.com/396562/110960446-61e64e80-8314-11eb-9d7c-2a760ea1fde0.png)


Cards with multiple printings did a funny thing with MWL entries, so i had to change that a bit and update the factinon id page and the deckbuilder pick your id pages to roll with this.
