### PR TITLE
Basic startup support

### DIFF
--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -259,7 +259,8 @@ var Filters = {},
     <div role="tabpanel" class="tab-pane" id="tab-pane-collection">
     <div class="panel panel-default">
       <div class="panel-heading">Select your packs |
-        <a href="#" id="collection_current">Current Cardpool</a> |
+        <a href="#" id="collection_startup">Startup</a> |
+        <a href="#" id="collection_standard">Standard</a> |
         <a href="#" id="collection_all">All</a> |
         <a href="#" id="collection_none">None</a></div>
       <div class="panel-body filter" id="pack_code"></div>

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -121,6 +121,9 @@
                 <table>
                     <thead>
                         <tr>
+                            <th class="legality-{{ card.startup_legality }}"> Startup Card Pool</th>
+                        </tr>
+                        <tr>
                             <th class="legality-{{ card.standard_legality }}"> Standard Card Pool</th>
                         </tr>
                         <tr>

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -469,7 +469,6 @@ class SearchController extends Controller
                 $cardinfo['available'] = $availability[$pack->getCode()];
 
                 $currentRotationCycles = [];
-
                 if ($view == "zoom") {
                     $cardVersions = $versions[$card->getTitle()];
 
@@ -481,6 +480,11 @@ class SearchController extends Controller
                     $cardinfo['versions'] = [];
                     $standard_legal = true;
                     $all_versions_rotated = true;
+
+                    // Startup legality is currently hard-coded since the DB doesn't know anything about it.
+                    $startupCycles = ['ashes' => true, 'system-gateway' => true, 'system-update-2021' => true];
+                    $startup_legal = false;
+
                     foreach ($cardVersions as $version) {
                         $v = $cardsData->getCardInfo($version, $locale);
                         $cardinfo['versions'][] = $v;
@@ -492,11 +496,16 @@ class SearchController extends Controller
                         if (array_key_exists($v['cycle_code'], $currentRotationCycles)) {
                           $all_versions_rotated = false;
                         }
+                        // Any printing of this card in a valid Startup cycle means the card is Startup legal.
+                        if (array_key_exists($v['cycle_code'], $startupCycles)) {
+                          $startup_legal = true;
+                        }
                     }
 
                     $cardinfo['reviews'] = $cardsData->get_reviews($cardVersions);
                     $cardinfo['rulings'] = $cardsData->get_rulings($cardVersions);
                     $cardinfo['mwl_info'] = $cardsData->get_mwl_info($cardVersions);
+                    $cardinfo['startup_legality'] = $startup_legal ? 'legal' : 'banned';
 
                     if ($standard_legal) {
                         $cardinfo['standard_legality'] = $all_versions_rotated ? 'rotated' : 'legal';

--- a/web/js/deck.js
+++ b/web/js/deck.js
@@ -176,7 +176,7 @@ function select_only_latest_cards(matchingCards) {
 }
 
 function create_collection_tab(initialPackSelection) {
-    var rotated_cycles = Array();
+  var rotated_cycles = Array();
   rotated_cycles['draft'] = 1;
   rotated_cycles['napd'] = 1;
   NRDB.data.cycles.find( { "rotated": true } ).forEach(function(cycle) { rotated_cycles[cycle.code] = 1; });
@@ -184,7 +184,24 @@ function create_collection_tab(initialPackSelection) {
   var rotated_packs = Array();
   NRDB.data.packs.find().forEach(function(pack) { if (rotated_cycles[pack.cycle.code]) { rotated_packs[pack.code] = 1; } });
 
-  $('#collection_current').on('click', function(event) {
+  $('#collection_startup').on('click', function(event) {
+    let startup_cycles = Array();
+    startup_cycles['ashes'] = 1;
+    startup_cycles['system-gateway'] = 1;
+    startup_cycles['system-update-2021'] = 1;
+    let startup_packs = Array();
+    startup_packs['df'] = 1;
+    startup_packs['urbp'] = 1;
+    startup_packs['ur'] = 1;
+    startup_packs['sg'] = 1;
+    startup_packs['su21'] = 1;
+    event.preventDefault();
+    $('#pack_code').find(':checkbox').each(function() {
+      $(this).prop('checked', (startup_cycles[$(this).prop('name')] || startup_packs[$(this).prop('name')]));
+    });
+    update_collection_packs();
+  });
+  $('#collection_standard').on('click', function(event) {
     event.preventDefault();
     $('#pack_code').find(':checkbox').each(function() {
       $(this).prop('checked', !(rotated_cycles[$(this).prop('name')] || rotated_packs[$(this).prop('name')]));
@@ -217,8 +234,8 @@ function create_collection_tab(initialPackSelection) {
     var is_checked = released || sets_in_deck[pack.code] || initialPackSelection[pack.code] !== false;
     return $container.addClass("checkbox").append('<label><input type="checkbox" name="' + pack.code + '"' + (is_checked ? ' checked="checked"' : '')+ '>' + pack.name + '</label>');
   };
-  _.sortBy(NRDB.data.cycles.find(), 'position').forEach(function (cycle) {
-    var packs = _.sortBy(NRDB.data.packs.find({cycle_code:cycle.code}), 'position');
+  _.sortBy(NRDB.data.cycles.find(), 'position').reverse().forEach(function (cycle) {
+    var packs = _.sortBy(NRDB.data.packs.find({cycle_code:cycle.code}), 'position').reverse();
     if(cycle.size === 1) {
       if(packs.length) {
         var $div = f(packs[0], $('<div></div>'));

--- a/web/js/deck.js
+++ b/web/js/deck.js
@@ -197,14 +197,14 @@ function create_collection_tab(initialPackSelection) {
     startup_packs['su21'] = 1;
     event.preventDefault();
     $('#pack_code').find(':checkbox').each(function() {
-      $(this).prop('checked', (startup_cycles[$(this).prop('name')] || startup_packs[$(this).prop('name')]));
+      $(this).prop('checked', Boolean(startup_cycles[$(this).prop('name')] || startup_packs[$(this).prop('name')]));
     });
     update_collection_packs();
   });
   $('#collection_standard').on('click', function(event) {
     event.preventDefault();
     $('#pack_code').find(':checkbox').each(function() {
-      $(this).prop('checked', !(rotated_cycles[$(this).prop('name')] || rotated_packs[$(this).prop('name')]));
+      $(this).prop('checked', !Boolean(rotated_cycles[$(this).prop('name')] || rotated_packs[$(this).prop('name')]));
     });
     update_collection_packs();
   });


### PR DESCRIPTION
Sort the packs in the deckbuilder newest -> oldest.
Change pack selection to Startup | Standard | All | None
![Screenshot 2021-03-13 at 7 00 04 PM](https://user-images.githubusercontent.com/396562/111054056-efb65c80-842e-11eb-8852-6557d393e9cb.png)

 Add a simple Startup Card Pool indicator to the card page.
![Screenshot 2021-03-13 at 6 21 45 PM](https://user-images.githubusercontent.com/396562/111054061-f5ac3d80-842e-11eb-8ba9-a9b554c7e54c.png)
![Screenshot 2021-03-13 at 6 20 42 PM](https://user-images.githubusercontent.com/396562/111054062-f644d400-842e-11eb-80b5-71827bd04678.png)
