### PR TITLE
Handle multiple Illustrators more gracefully

### DIFF
--- a/app/Resources/views/Search/display-full.html.twig
+++ b/app/Resources/views/Search/display-full.html.twig
@@ -38,10 +38,10 @@
                   <div class="card-illustrator">
                     <small>
                     {{ card.faction_name }} &bull;
-{% for illustrator in card.illustrators %}
-                    <a href="{{ path('cards_find',{type:'find',_locale:app.request.locale,'view':'images','q':'i:"' ~ illustrator ~ '"'}) }}">{{ illustrator }}</a> &bull;
-{% endfor %}
-					<span class="icon icon-{{ card.cycle_code }}"></span>
+                    {% for illustrator in card.illustrators %}
+                        <a href="{{ path('cards_find',{type:'find',_locale:app.request.locale,'view':'images','q':'i:"' ~ illustrator ~ '"'}) }}">{{ illustrator }}</a> &bull;
+                    {% endfor %}
+                    <span class="icon icon-{{ card.cycle_code }}"></span>
                     {{ card.pack_name }} {{ card.position }}
                     </small>
                   </div>

--- a/app/Resources/views/Search/display-full.html.twig
+++ b/app/Resources/views/Search/display-full.html.twig
@@ -38,7 +38,9 @@
                   <div class="card-illustrator">
                     <small>
                     {{ card.faction_name }} &bull;
-                    {% if card.illustrator %}<a href="{{ path('cards_find',{type:'find',_locale:app.request.locale,'view':'images','q':'i:"' ~ card.illustrator ~ '"'}) }}">{{ card.illustrator }}</a> &bull; {% endif %}
+{% for illustrator in card.illustrators %}
+                    <a href="{{ path('cards_find',{type:'find',_locale:app.request.locale,'view':'images','q':'i:"' ~ illustrator ~ '"'}) }}">{{ illustrator }}</a> &bull;
+{% endfor %}
 					<span class="icon icon-{{ card.cycle_code }}"></span>
                     {{ card.pack_name }} {{ card.position }}
                     </small>

--- a/app/Resources/views/Search/display-text.html.twig
+++ b/app/Resources/views/Search/display-text.html.twig
@@ -35,7 +35,9 @@
     {{ card.flavor|raw|nl2br }}
   </p>
   <p style="font-size:86.5%">
-    {{ card.illustrator }}
+    {% for illustrator in card.illustrators %}
+      {{ illustrator }}
+    {% endfor %}
   </p>
   <p>
     <span class="icon icon-{{ card.cycle_code }}"></span> {{ card.pack_name }} {{ card.position }} &bull; {{ card.faction_name }}

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -96,8 +96,10 @@
                 {% if card.illustrator %}
                     <div class="card-illustrator">
                         <small>
-                            Illustrated by <a href="{{ path('cards_find', {type:'find', _locale:app.request.locale, 'view':'images', 'q':'i:"' ~ card.illustrator ~ '"'}) }}">
-                                {{ card.illustrator }}
+                            Illustrated by
+                                {% for illustrator in card.illustrators %}
+                                    <a href="{{ path('cards_find',{type:'find',_locale:app.request.locale,'view':'images','q':'i:"' ~ illustrator ~ '"'}) }}">{{ illustrator }}</a>
+                                {% endfor %}
                             </a>
                         </small>
                     </div>

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -682,6 +682,7 @@ class CardsData
             "faction_cost_dots" => $card->getFactionCostDots(),
             "flavor"            => $card->getFlavor(),
             "illustrator"       => $card->getIllustrator(),
+            "illustrators"      => preg_split("/\s*(&|\/|and)\s*/", $card->getIllustrator()),
             "influencelimit"    => $card->getInfluenceLimit(),
             "memoryunits"       => $card->getMemoryCost(),
             "minimumdecksize"   => $card->getMinimumDeckSize(),


### PR DESCRIPTION
Some cards have multiple illustrators.  Split them (stripping out the various ways multiple illustrators are indicated) and make them individually clickable where we allow illustrator links.

![Screenshot 2021-03-17 11 18 18 PM](https://user-images.githubusercontent.com/396562/111573523-b2c4cf80-8778-11eb-881a-851804f75640.png)
![Screenshot 2021-03-17 11 24 21 PM](https://user-images.githubusercontent.com/396562/111573528-b5272980-8778-11eb-84bf-f13aeb97c0db.png)
![Screenshot 2021-03-17 11 27 08 PM](https://user-images.githubusercontent.com/396562/111573532-b7898380-8778-11eb-8ba0-8e09739de637.png)
