### PR TITLE
Update php session settings for longer logins

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,6 +25,11 @@ framework:
         # https://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         handler_id: session.handler.native_file
         save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
+        # https://symfony.com/doc/current/components/http_foundation/session_configuration.html#configuring-garbage-collection
+        gc_probability: null
+        # One year = 365 * 24 * 60 * 60
+        gc_lifetime: 31536000
+        cookie_lifetime: 31536000
     fragments: ~
     http_method_override: true
     assets:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -27,9 +27,9 @@ framework:
         save_path: '%kernel.project_dir%/var/sessions/%kernel.environment%'
         # https://symfony.com/doc/current/components/http_foundation/session_configuration.html#configuring-garbage-collection
         gc_probability: null
-        # One year = 365 * 24 * 60 * 60
-        gc_lifetime: 31536000
-        cookie_lifetime: 31536000
+        # One month = 30 * 24 * 60 * 60
+        gc_maxlifetime: 2592000
+        cookie_lifetime: 2592000
     fragments: ~
     http_method_override: true
     assets:


### PR DESCRIPTION
Here we set gc_lifetime and cookie_lifetime to 1 year so that User Logins don't expire too quickly.  The defaults are "When you close your browser window" and 24 minutes (for the server session), which is too short for most users.
