### PR TITLE
Fix influence for gateway neutral ids and mark them as illegal.

### DIFF
--- a/app/Resources/views/Search/display-full.html.twig
+++ b/app/Resources/views/Search/display-full.html.twig
@@ -20,8 +20,8 @@
                     <span class="card-type">{{ card.type_name }}</span>{% if card.subtype %}<span class="card-keywords">: {{ card.subtype }}</span>{% endif %}
                     <span class="card-prop">&bull;
                     {% if card.type_code == "agenda" %} Adv: {{ card.advancementcost }} &bull; Score: {{ card.agendapoints }} {% endif %}
-                    {% if card.type_code == "identity" and card.side_code == "corp" %}Deck: {{ card.minimumdecksize }} &bull; Influence: {% if card.influencelimit is null %} &#8734; {% else %} {{ card.influencelimit }} {% endif %} {% endif %}
-                    {% if card.type_code == "identity" and card.side_code == "runner" %}Link: {{ card.baselink }} &bull; Deck: {{ card.minimumdecksize }} &bull; Influence: {% if card.influencelimit is null %} &#8734; {% else %} {{ card.influencelimit }} {% endif %} {% endif %}
+                    {% if card.type_code == "identity" and card.side_code == "corp" %}Deck: {{ card.minimumdecksize }} &bull; Influence: {% if card.influencelimit ?? 0 == 0 %} &#8734; {% else %} {{ card.influencelimit }} {% endif %} {% endif %}
+                    {% if card.type_code == "identity" and card.side_code == "runner" %}Link: {{ card.baselink }} &bull; Deck: {{ card.minimumdecksize }} &bull; Influence: {% if card.influencelimit ?? 0 == 0 %} &#8734; {% else %} {{ card.influencelimit }} {% endif %} {% endif %}
                     {% if card.type_code == "operation" or card.type_code == "event" %}Cost: {{ card.cost }} {% if card.trash is not null %}&bull; Trash: {{ card.trash }} {% endif %} &bull; Influence: {{ card.factioncost }}{% endif %}
                     {% if card.type_code == "resource" or card.type_code == "hardware" %}Install: {{ card.cost }} &bull; Influence: {{ card.factioncost }}{% endif %}
                     {% if card.type_code == "program" %}Install: {{ card.cost }} &bull; Memory: {{ card.memoryunits }} {% if card.strength is not null %}&bull; Strength: {{ card.strength }}{% endif %} &bull; Influence: {{ card.factioncost }}{% endif %}

--- a/app/Resources/views/Search/display-text.html.twig
+++ b/app/Resources/views/Search/display-text.html.twig
@@ -19,8 +19,8 @@
   </p>
   <p class="card-props">
     {% if card.type_code == "agenda" %} Adv: {{ card.advancementcost }} &bull; Score: {{ card.agendapoints }} {% endif %}
-    {% if card.type_code == "identity" and card.side_code == "corp" %}Deck: {{ card.minimumdecksize }} &bull; Influence: {% if card.influencelimit is null %} &#8734; {% else %} {{ card.influencelimit }} {% endif %} {% endif %}
-    {% if card.type_code == "identity" and card.side_code == "runner" %}Link: {{ card.baselink }} &bull; Deck: {{ card.minimumdecksize }} &bull; Influence: {% if card.influencelimit is null %} &#8734; {% else %} {{ card.influencelimit }} {% endif %} {% endif %}
+    {% if card.type_code == "identity" and card.side_code == "corp" %}Deck: {{ card.minimumdecksize }} &bull; Influence: {% if card.influencelimit ?? 0 == 0 %} &#8734; {% else %} {{ card.influencelimit }} {% endif %} {% endif %}
+    {% if card.type_code == "identity" and card.side_code == "runner" %}Link: {{ card.baselink }} &bull; Deck: {{ card.minimumdecksize }} &bull; Influence: {% if card.influencelimit ?? 0 == 0 %} &#8734; {% else %} {{ card.influencelimit }} {% endif %} {% endif %}
     {% if card.type_code == "operation" or card.type_code == "event" %}Cost: {{ card.cost }} {% if card.trash is not null %}&bull; Trash: {{ card.trash }} {% endif %}&bull; Influence: {{ card.factioncost }}{% endif %}
     {% if card.type_code == "resource" or card.type_code == "hardware" %}Install: {{ card.cost }} &bull; Influence: {{ card.factioncost }}{% endif %}
     {% if card.type_code == "program" %}Install: {{ card.cost }} &bull; Memory: {{ card.memoryunits }} {% if card.strength %}&bull; Strength: {{ card.strength }}{% endif %} &bull; Influence: {{ card.factioncost }}{% endif %}

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -49,7 +49,7 @@
                         Deck size: {{ card.minimumdecksize }}
                         &bull;
                         Influence:
-                        {{ card.influencelimit ?? "&#8734;" }}
+                        {% if card.influencelimit ?? 0 == 0 %}&#8734;{% else %}{{ card.influencelimit }}{% endif %}
                         {% if card.side_code == "runner" %}
                             &bull;
                             Link: {{ card.baselink }}

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -488,6 +488,12 @@ class SearchController extends Controller
                     foreach ($cardVersions as $version) {
                         $v = $cardsData->getCardInfo($version, $locale);
                         $cardinfo['versions'][] = $v;
+                        // The 2 tutorial-only identity cards are invalid for startup and standard formats.
+                        if ($v['code'] == '30077' || $v['code'] == '30076') {
+                            $standard_legal = false;
+                            $startup_legal = false;
+                            continue;
+                        }
                         // Draft and terminal directive campaign cards are not legal in standard.
                         if ($v['cycle_code'] == 'draft' || $v['pack_code'] == 'tdc') {
                             $standard_legal = false;

--- a/src/AppBundle/Service/Judge.php
+++ b/src/AppBundle/Service/Judge.php
@@ -284,7 +284,7 @@ class Judge
             }
         }
 
-        if ($influenceLimit !== null && $influenceSpent > $influenceLimit) {
+        if (!($influenceLimit == null || $influenceLimit == 0) && $influenceSpent > $influenceLimit) {
             $problem = 'influence';
         }
 

--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -350,7 +350,7 @@ function update_deck(options) {
     $('#identity').html('<a href="' + Routing.generate('cards_zoom', { card_code: Identity.code }) + '" data-target="#cardModal" data-remote="false" class="card" data-toggle="modal" data-index="' + Identity.code + '">' + parts[0] + ' <small>' + parts[1] + '</small></a>' + unicorn(Identity));
     $('#img_identity').prop('src', '/card_image/medium/' + Identity.code + '.jpg');
     InfluenceLimit = Identity.influence_limit;
-    if (typeof InfluenceLimit === "undefined")
+    if (InfluenceLimit == null || InfluenceLimit == 0)
         InfluenceLimit = Number.POSITIVE_INFINITY;
 
     check_decksize();


### PR DESCRIPTION
The starter ids aren't banned, but also aren't legal for standard format play, and presumably startup.
![Screenshot 2021-03-26 1 12 25 AM](https://user-images.githubusercontent.com/396562/112590307-9ce68880-8dd0-11eb-95e9-5703a5e08ce6.png)

They also had an issue with their influence, which was fixed.
![Screenshot 2021-03-26 1 11 42 AM](https://user-images.githubusercontent.com/396562/112590310-9d7f1f00-8dd0-11eb-929f-65283fc1d9d8.png)
![Screenshot 2021-03-26 1 10 57 AM](https://user-images.githubusercontent.com/396562/112590311-9d7f1f00-8dd0-11eb-89e7-b2746811534c.png)

legality and format stuff still needs more work, but this is a step in the right direction.