### PR TITLE
Return X for non-{Identity,Agenda} cards with null cost.

### DIFF
--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -1127,6 +1127,10 @@ class Card implements NormalizableInterface, TimestampableInterface
      */
     public function getFormattedCost()
     {
-        return $this->getCost() . "<span class=\"icon icon-credit\" aria-hidden=\"true\"></span><span class=\"icon-fallback\">[credit]</span>";
+		$cost = $this->getCost();
+		if ($cost == null && !($this->getType()->getName() == "Identity" || $this->getType()->getName() == "Agenda")) {
+			$cost = 'X';
+		}
+        return $cost . "<span class=\"icon icon-credit\" aria-hidden=\"true\"></span><span class=\"icon-fallback\">[credit]</span>";
     }
 }


### PR DESCRIPTION
Add X for X-cost (null in the db) cards.  Agenda & Identity cards have a null cost legitimately and are exempt here.

![Screenshot 2021-03-27 1 29 52 PM](https://user-images.githubusercontent.com/396562/112730645-b38bfd00-8f00-11eb-9e15-b38a79337dd1.png)
