### PR TITLE
Invert rotation logic

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -630,10 +630,10 @@ class ImportStdCommand extends ContainerAwareCommand
         // we need to check that manually.  If those are the same, just let the
         // existing handling do its work.
         if ($entityName === 'AppBundle\Entity\Rotation') {
-            $json_cycles = $data['cycles'];
+            $json_cycles = $data['rotated'];
             sort($json_cycles);
             $db_cycles = array();
-            foreach ($entity->GetCycles() as $c) {
+            foreach ($entity->GetRotated() as $c) {
                 array_push($db_cycles, $c->GetCode());
             }
             sort($db_cycles);

--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -175,8 +175,9 @@ class ImportStdCommand extends ContainerAwareCommand
         // rotation
 
         $output->writeln("Importing Rotation...");
-        $mwlFileInfo = $this->getFileInfo($path, 'rotations.json');
-        $imported = $this->importRotationJsonFile($mwlFileInfo);
+        $rotationFileInfo = $this->getFileInfo($path, 'rotations.json');
+        $imported = $this->importRotationJsonFile($rotationFileInfo);
+        $output->writeln("Imported: " . count($imported));
         if (!$force && count($imported)) {
             $question = new ConfirmationQuestion("Do you confirm? (Y/n) ", true);
             if (!$helper->ask($input, $output, $question)) {
@@ -459,7 +460,7 @@ class ImportStdCommand extends ContainerAwareCommand
             ], [], []);
             if ($rotation) {
                 $result[] = $rotation;
-                foreach ($rotationData['cycles'] as $cycle_code) {
+                foreach ($rotationData['rotated'] as $cycle_code) {
                     $cycle = $this->entityManager->getRepository('AppBundle:Cycle')->findOneBy(['code' => $cycle_code]);
                     if (!$cycle instanceof Cycle) {
                         continue;

--- a/src/AppBundle/Command/LegalityDecklistsRotationCommand.php
+++ b/src/AppBundle/Command/LegalityDecklistsRotationCommand.php
@@ -74,7 +74,6 @@ class LegalityDecklistsRotationCommand extends ContainerAwareCommand
                 if ($confirm && $oldId !== $rotation->getId()) {
                     $output->writeln("  updating decklist " . $decklist->getId());
                     $decklist->setRotation($rotation);
-                    $this->entityManager->persist($decklist);
                 }
             }
         }

--- a/src/AppBundle/Command/LegalityDecklistsRotationCommand.php
+++ b/src/AppBundle/Command/LegalityDecklistsRotationCommand.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use AppBundle\Service\RotationService;
 
 /**
  *
@@ -15,11 +16,15 @@ class LegalityDecklistsRotationCommand extends ContainerAwareCommand
 {
     /** @var EntityManagerInterface $entityManager */
     private $entityManager;
+    
+    /** @var RotationService $rotationService */
+    private $rotationService;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(EntityManagerInterface $entityManager, RotationService $rotationService)
     {
         parent::__construct();
         $this->entityManager = $entityManager;
+        $this->rotationService = $rotationService;
     }
 
     protected function configure()
@@ -51,6 +56,29 @@ class LegalityDecklistsRotationCommand extends ContainerAwareCommand
                 AND ny.rotated = 0);";
 
         $this->entityManager->getConnection()->executeQuery($sql);
+        
+        $rotations = $this->entityManager->getRepository('AppBundle:Rotation')->findBy([], ["dateStart" => "DESC"]);
+        $decklists = $this->entityManager->getRepository('AppBundle:Decklist')->findBy([]);
+        
+        foreach ($rotations as $rotation) {
+            $output->writeln("checking " . $rotation->getName());
+            
+            foreach ($decklists as $decklist) {
+                $confirm = $this->rotationService->isRotationCompatible($decklist, $rotation);
+                
+                $oldId = null;
+                if ($decklist->getRotation()) {
+                    $oldId = $decklist->getRotation()->getId();
+                }
+                
+                if ($confirm && $oldId !== $rotation->getId()) {
+                    $output->writeln("  updating decklist " . $decklist->getId());
+                    $decklist->setRotation($rotation);
+                    $this->entityManager->persist($decklist);
+                }
+            }
+        }
+        $this->entityManager->flush();
 
         $output->writeln("<info>Done</info>");
     }

--- a/src/AppBundle/Entity/Cycle.php
+++ b/src/AppBundle/Entity/Cycle.php
@@ -15,7 +15,7 @@ class Cycle implements NormalizableInterface, TimestampableInterface, CodeNameIn
 {
     /**
      * @var Collection|Rotation[]
-     * @ORM\ManyToMany(targetEntity="Rotation", mappedBy="cycles")
+     * @ORM\ManyToMany(targetEntity="Rotation", mappedBy="rotated")
      */
     protected $rotations;
 

--- a/src/AppBundle/Entity/Rotation.php
+++ b/src/AppBundle/Entity/Rotation.php
@@ -26,7 +26,7 @@ class Rotation implements NormalizableInterface, TimestampableInterface
      *     }
      * )
      */
-    protected $cycles;
+    protected $rotated;
 
     /**
      * @var integer
@@ -66,7 +66,7 @@ class Rotation implements NormalizableInterface, TimestampableInterface
 
     public function __construct()
     {
-        $this->cycles = new ArrayCollection();
+        $this->rotated = new ArrayCollection();
     }
 
     public function __toString()
@@ -76,9 +76,9 @@ class Rotation implements NormalizableInterface, TimestampableInterface
 
     public function normalize()
     {
-        $cycles = [];
-        foreach ($this->cycles as $cycle) {
-            $cycles[] = $cycle->getCode();
+        $rotated = [];
+        foreach ($this->rotated as $cycle) {
+            $rotated[] = $cycle->getCode();
         }
 
         return  [
@@ -88,7 +88,7 @@ class Rotation implements NormalizableInterface, TimestampableInterface
             'code' => $this->code,
             'name' => $this->name,
             'date_start' => $this->dateStart ? $this->dateStart->format('Y-m-d') : null,
-            'cycles' => $cycles
+            'rotated' => $rotated
         ];
     }
 
@@ -140,36 +140,36 @@ class Rotation implements NormalizableInterface, TimestampableInterface
     }
 
     /** @return Collection|Cycle[] */
-    public function getCycles()
+    public function getRotated()
     {
-        return $this->cycles;
+        return $this->rotated;
     }
 
-    /** @param Collection|Cycle[] $cycles */
-    public function setCycles(Collection $cycles)
+    /** @param Collection|Cycle[] $rotated */
+    public function setRotated(Collection $rotated)
     {
-        $this->clearCycles();
-        foreach ($cycles as $cycle) {
+        $this->clearRotated();
+        foreach ($rotated as $cycle) {
             $this->addCycle($cycle);
         }
 
         return $this;
     }
 
-    public function clearCycles()
+    public function clearRotated()
     {
-        foreach ($this->getCycles() as $cycle) {
+        foreach ($this->getRotated() as $cycle) {
             $this->removeCycle($cycle);
         }
-        $this->cycles->clear();
+        $this->rotated->clear();
 
         return $this;
     }
 
     public function removeCycle(Cycle $cycle)
     {
-        if ($this->cycles->contains($cycle)) {
-            $this->cycles->removeElement($cycle);
+        if ($this->rotated->contains($cycle)) {
+            $this->rotated->removeElement($cycle);
             $cycle->removeRotation($this);
         }
 
@@ -178,8 +178,8 @@ class Rotation implements NormalizableInterface, TimestampableInterface
 
     public function addCycle(Cycle $cycle)
     {
-        if ($this->cycles->contains($cycle) === false) {
-            $this->cycles->add($cycle);
+        if ($this->rotated->contains($cycle) === false) {
+            $this->rotated->add($cycle);
             $cycle->addRotation($this);
         }
 

--- a/src/AppBundle/Resources/config/doctrine/Cycle.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Cycle.orm.yml
@@ -14,7 +14,7 @@ AppBundle\Entity\Cycle:
     manyToMany:
         rotations:
             targetEntity: Rotation
-            mappedBy: cycles
+            mappedBy: rotated
             cascade: ["remove"]
     fields:
         id:

--- a/src/AppBundle/Resources/config/doctrine/Rotation.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Rotation.orm.yml
@@ -2,7 +2,7 @@ AppBundle\Entity\Rotation:
     type: entity
     table: rotation
     manyToMany:
-        cycles:
+        rotated:
             targetEntity: Cycle
             inversedBy: rotations
             joinTable:

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -618,13 +618,13 @@ class CardsData
                     }
                     if ($rotation) {
                         // Add the valid cycles for the requested rotation and add them to the WHERE clause for the query.
-                        $cycles = $rotation->normalize()["cycles"];
+                        $cycles = $rotation->normalize()["rotated"];
                         $placeholders = array();
                         foreach($cycles as $cycle) {
                             array_push($placeholders, "?$i");
                             $parameters[$i++] = $cycle;
                         }
-                        $clauses[] = "(y.code in (" . implode(", ", $placeholders) . "))";
+                        $clauses[] = "(y.code not in (" . implode(", ", $placeholders) . "))";
                     }
                     $i++;
                     break;

--- a/src/AppBundle/Service/RotationService.php
+++ b/src/AppBundle/Service/RotationService.php
@@ -84,11 +84,9 @@ class RotationService
             $cycles[$slot->getCard()->getPack()->getCycle()->getCode()] = 1;
         }
         
-        $allCycles = array_map(function(Cycle $cycle) { return $cycle->getCode(); }, $this->entityManager->getRepository(Cycle::class)->findBy([]));
+        $usedCycles = array_keys($cycles);
         $rotatedCycles = array_map(function (Cycle $cycle) { return $cycle->getCode(); }, $rotation->getRotated()->toArray());
-        $remainingCycles = array_diff($allCycles, $rotatedCycles);
-        
-        return count(array_diff(array_keys($cycles), $remainingCycles)) === 0;
+        return count(array_intersect($usedCycles, $rotatedCycles)) === 0;
     }
 
     /**

--- a/src/AppBundle/Service/RotationService.php
+++ b/src/AppBundle/Service/RotationService.php
@@ -83,10 +83,12 @@ class RotationService
         foreach ($decklist->getSlots() as $slot) {
             $cycles[$slot->getCard()->getPack()->getCycle()->getCode()] = 1;
         }
-
-        return count(array_diff(array_keys($cycles), array_map(function (Cycle $cycle) {
-            return $cycle->getCode();
-        }, $rotation->getCycles()->toArray()))) === 0;
+        
+        $allCycles = array_map(function(Cycle $cycle) { return $cycle->getCode(); }, $this->entityManager->getRepository(Cycle::class)->findBy([]));
+        $rotatedCycles = array_map(function (Cycle $cycle) { return $cycle->getCode(); }, $rotation->getRotated()->toArray());
+        $remainingCycles = array_diff($allCycles, $rotatedCycles);
+        
+        return count(array_diff(array_keys($cycles), $remainingCycles)) === 0;
     }
 
     /**


### PR DESCRIPTION
Revival of https://github.com/NetrunnerDB/netrunnerdb/pull/209

Implements the data change from https://github.com/NetrunnerDB/netrunner-cards-json/pull/575

When this gets merged, the steps to deploy this are as follows:
* update the database schema using `php bin/console doctrine:schema:update --force`
* manually delete the contents of the `rotation_cycle` table
* import the new rotations.json with the usual import command

At least in my test db, this did not create new `rotation_id`s (so that all previous decks still point to the correct rotation), but in any case, do make sure to backup the database before the migration… :)

If this does not work somehow, you’d either have to run the `app:legality:decklists-rotation` command to update existing decklists, or manually fix the `decklist.rotation_id` column to update rotations, the mapping from old to new rotations should be straightforward 1:1.
