### PR TITLE
Allow "Any Corp"/"Any Runner" to select properly.

### DIFF
--- a/src/AppBundle/Controller/DecklistsController.php
+++ b/src/AppBundle/Controller/DecklistsController.php
@@ -335,7 +335,14 @@ class DecklistsController extends Controller
         ];
         $params['sort_' . $sort] = ' selected="selected"';
         if (!empty($faction_code)) {
-            $params['faction_' . CardsData::$faction_letters[$faction_code]] = ' selected="selected"';
+            if ($faction_code == 'corp') {
+                $params['faction_C'] = ' selected="selected"';
+            } elseif ($faction_code == 'runner') {
+                $params['faction_R'] = ' selected="selected"';
+
+            } else {
+                $params['faction_' . CardsData::$faction_letters[$faction_code]] = ' selected="selected"';
+            }
         }
 
         if (!empty($cards_code) && is_array($cards_code)) {


### PR DESCRIPTION
this threw an error locally, but just doesn't stick on the decklist form in prod.  The search worked properly, but the select items wouldn't persist.