### PR TITLE
Ignore the corp/runner suggestion json files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 /web/bundles/
 .php_cs.cache
 /web/card_image/
+/web/corp.json
+/web/runner.json


### PR DESCRIPTION
the server generates these suggestion JSON files and we don't check them in.