### PR TITLE
Tidy up decklist search packs options to match deckbuilder.

### DIFF
--- a/app/Resources/views/Search/form.html.twig
+++ b/app/Resources/views/Search/form.html.twig
@@ -79,16 +79,34 @@
             <button type="submit" class="btn btn-primary btn-block">Search</button>
         </div>
         <div class="col-sm-4">
-            <p><a data-toggle="collapse" data-target="#allowed_packs" href="#allowed_packs">Select allowed packs</a> (<span id="packs-on">{{ on }}</span> on, <span id="packs-off">{{ off }}</span> off)</p>
+            <p><a data-toggle="collapse" data-target="#allowed_packs" href="#allowed_packs">Select allowed packs</a> <span id="packs-on"></span> <span id="packs-off"></span></p>
             <div id="allowed_packs" class="collapse">
-                {% for category in allowed %}
-                    <p><small>{{ category.label }}</small></p>
-                    {% for pack in category.packs %}
-                        <div class="checkbox"><label class="{% if pack.future %}pack-future{% endif %}"><input type="checkbox" name="packs[]" value="{{ pack.id }}" {% if pack.checked %}checked="checked" {% endif %}>{{ pack.label }}</label></div>
+                <div>
+                    <a href="#" id="select_startup">Startup</a> |
+                    <a href="#" id="select_standard">Standard</a> |
+                    <a href="#" id="select_all">All</a> |
+                    <a href="#" id="select_none">None</a>
+                </div>
+
+                {% for category in cycles_and_packs %}
+                    <div class="checkbox -bs-checklist">
+                        {% if category.packs|length == 1 %}
+                            <div class="checkbox" data-toggle="checklist">
+                                <li class="checkbox"><label class="{% if category.packs[0].future %}pack-future{% endif %}"><input type="checkbox" name="packs[]" value="{{ category.packs[0].code }}" {% if category.packs[0].checked %}checked="checked" {% endif %}>{{ category.packs[0].label }}</label></li>
+                            </div>
+                        {% else %}
+                            <div class="checkbox" data-toggle="checklist">
+                              <label><input type="checkbox" class="cycle_checkbox" value="{{ category.code }}" id="cycle_{{ category.cycle_id }}" name="cycle_{{ category.cycle_id}}" {% if category.checked %}checked="checked"{% endif %}>{{ category.label }}</label>
+                            </div>
+                            <ul class="checkbox checklist-items">
+                            {% for pack in category.packs %}
+                                <li class="checkbox"><label class="{% if pack.future %}pack-future{% endif %}"><input type="checkbox" name="packs[]" value="{{ pack.code }}" {% if pack.checked %}checked="checked" {% endif %}>{{ pack.label }}</label></li>
+
                             {% endfor %}
-                        {% endfor %}
-                <a href="#" id="select_all"><span class="glyphicon glyphicon-ok"></span> all</a>
-                / <a href="#" id="select_none"><span class="glyphicon glyphicon-remove"></span> none</a>
+                            </ul>
+                        {% endif %}
+                    </div>
+                {% endfor %}
             </div>
         </div>
     </div>

--- a/src/AppBundle/Controller/DecklistsController.php
+++ b/src/AppBundle/Controller/DecklistsController.php
@@ -183,23 +183,23 @@ class DecklistsController extends Controller
                 continue;
             }
 
-                $entry = ["label" => $cycle->getName(), "code" => $cycle->getCode(), "cycle_id" => $cycle->getId(), "packs" => []];
-                $packs = $cycle->getPacks()->toArray();
-                usort($packs, function ($a, $b) {
-                    if ($a->getPosition() == $b->getPosition()) { return 0; }
-                    return $a->getPosition() < $b->getPosition() ? 1 : -1;
-                });
+            $entry = ["label" => $cycle->getName(), "code" => $cycle->getCode(), "cycle_id" => $cycle->getId(), "packs" => []];
+            $packs = $cycle->getPacks()->toArray();
+            usort($packs, function ($a, $b) {
+                if ($a->getPosition() == $b->getPosition()) { return 0; }
+                return $a->getPosition() < $b->getPosition() ? 1 : -1;
+            });
 
-                $num_packs_on = 0;
-                foreach ($packs as $pack) {
-                    $checked = count($pack_codes) > 0 ? in_array($pack->getCode(), $pack_codes) : $pack->getDateRelease() !== null;
-                    if ($checked) {
-                        ++$num_packs_on;
-                    }
-                    $entry['packs'][] = ["code" => $pack->getCode(), "label" => $pack->getName(), "checked" => $checked, "future" => $pack->getDateRelease() === null];
+            $num_packs_on = 0;
+            foreach ($packs as $pack) {
+                $checked = count($pack_codes) > 0 ? in_array($pack->getCode(), $pack_codes) : $pack->getDateRelease() !== null;
+                if ($checked) {
+                    ++$num_packs_on;
                 }
-                $entry['checked'] = $num_packs_on == count($packs);
-                $cycles_and_packs[] = $entry;
+                $entry['packs'][] = ["code" => $pack->getCode(), "label" => $pack->getName(), "checked" => $checked, "future" => $pack->getDateRelease() === null];
+            }
+            $entry['checked'] = $num_packs_on == count($packs);
+            $cycles_and_packs[] = $entry;
         }
         return $cycles_and_packs;
     }

--- a/src/AppBundle/Controller/DecklistsController.php
+++ b/src/AppBundle/Controller/DecklistsController.php
@@ -171,6 +171,39 @@ class DecklistsController extends Controller
         ], $response);
     }
 
+    // Defaults to checked if the pack is not draft and has been officiallly released.
+    // Will check only packs with entries in $pack_codes if it is non-empty.
+    private function getCyclesAndPacks(EntityManagerInterface $entityManager, array $pack_codes = [])
+    {
+        $cycles_and_packs = [];
+        $list_cycles = $entityManager->getRepository('AppBundle:Cycle')->findBy([], ["position" => "DESC"]);
+        foreach ($list_cycles as $cycle) {
+            $size = $cycle->getPacks()->count();
+            if ($size == 0) {
+                continue;
+            }
+
+                $entry = ["label" => $cycle->getName(), "code" => $cycle->getCode(), "cycle_id" => $cycle->getId(), "packs" => []];
+                $packs = $cycle->getPacks()->toArray();
+                usort($packs, function ($a, $b) {
+                    if ($a->getPosition() == $b->getPosition()) { return 0; }
+                    return $a->getPosition() < $b->getPosition() ? 1 : -1;
+                });
+
+                $num_packs_on = 0;
+                foreach ($packs as $pack) {
+                    $checked = count($pack_codes) > 0 ? in_array($pack->getCode(), $pack_codes) : $pack->getDateRelease() !== null;
+                    if ($checked) {
+                        ++$num_packs_on;
+                    }
+                    $entry['packs'][] = ["code" => $pack->getCode(), "label" => $pack->getName(), "checked" => $checked, "future" => $pack->getDateRelease() === null];
+                }
+                $entry['checked'] = $num_packs_on == count($packs);
+                $cycles_and_packs[] = $entry;
+        }
+        return $cycles_and_packs;
+    }
+
     /**
      * @param Request                $request
      * @param EntityManagerInterface $entityManager
@@ -192,43 +225,7 @@ class DecklistsController extends Controller
                 ORDER BY f.side_id ASC, f.name ASC"
         )->fetchAll();
 
-        $categories = [];
-        $on = 0;
-        $off = 0;
-        $categories[] = ["label" => "Core / Deluxe", "packs" => []];
-        $list_cycles = $entityManager->getRepository('AppBundle:Cycle')->findBy([], ["position" => "ASC"]);
-        foreach ($list_cycles as $cycle) {
-            $size = $cycle->getPacks()->count();
-            if ($size == 0) {
-                continue;
-            }
-            $first_pack = $cycle->getPacks()[0];
-            if ($size === 1 && $first_pack->getName() == $cycle->getName()) {
-                if ($cycle->getPosition() == 0) {
-                    $checked = false;
-                } else {
-                    $checked = $first_pack->getDateRelease() !== null;
-                }
-                if ($checked) {
-                    $on++;
-                } else {
-                    $off++;
-                }
-                $categories[0]["packs"][] = ["id" => $first_pack->getId(), "label" => $first_pack->getName(), "checked" => $checked, "future" => $first_pack->getDateRelease() === null];
-            } else {
-                $category = ["label" => $cycle->getName(), "packs" => []];
-                foreach ($cycle->getPacks() as $pack) {
-                    $checked = $pack->getDateRelease() !== null;
-                    if ($checked) {
-                        $on++;
-                    } else {
-                        $off++;
-                    }
-                    $category['packs'][] = ["id" => $pack->getId(), "label" => $pack->getName(), "checked" => $checked, "future" => $pack->getDateRelease() === null];
-                }
-                $categories[] = $category;
-            }
-        }
+        $cycles_and_packs = $this->getCyclesAndPacks($entityManager);
 
         $list_mwl = $entityManager->getRepository('AppBundle:Mwl')->findBy([], ['dateStart' => 'DESC']);
         $list_rotations = $entityManager->getRepository(Rotation::class)->findBy([], ['dateStart' => 'DESC']);
@@ -241,16 +238,14 @@ class DecklistsController extends Controller
             'form'      => $this->renderView(
                 '/Search/form.html.twig',
                 [
-                    'allowed'        => $categories,
-                    'on'             => $on,
-                    'off'            => $off,
-                    'author'         => '',
-                    'title'          => '',
-                    'list_mwl'       => $list_mwl,
-                    'mwl_code'       => '',
-                    'list_rotations' => $list_rotations,
-                    'rotation_id'    => '',
-                    'is_legal'       => '',
+                    'cycles_and_packs' => $cycles_and_packs,
+                    'author'           => '',
+                    'title'            => '',
+                    'list_mwl'         => $list_mwl,
+                    'mwl_code'         => '',
+                    'list_rotations'   => $list_rotations,
+                    'rotation_id'      => '',
+                    'is_legal'         => '',
                 ]
             ),
         ], $response);
@@ -276,62 +271,20 @@ class DecklistsController extends Controller
         $rotation_id = $request->query->get('rotation_id');
         $is_legal = $request->query->get('is_legal');
 
-        if (!is_array($packs)) {
-            $packs = $dbh->executeQuery("SELECT id FROM pack")->fetchAll(\PDO::FETCH_COLUMN);
-        }
-
-        $categories = [];
-        $on = 0;
-        $off = 0;
-        $categories[] = ["label" => "Core / Deluxe", "packs" => []];
-        $list_cycles = $entityManager->getRepository('AppBundle:Cycle')->findBy([], ["position" => "ASC"]);
-        foreach ($list_cycles as $cycle) {
-            $size = $cycle->getPacks()->count();
-            if ($size == 0) {
-                continue;
-            }
-            $first_pack = $cycle->getPacks()[0];
-            if ($size === 1 && $first_pack->getName() == $cycle->getName()) {
-                if ($cycle->getPosition() == 0) {
-                    $checked = false;
-                } else {
-                    $checked = count($packs) ? in_array($first_pack->getId(), $packs) : true;
-                }
-                if ($checked) {
-                    $on++;
-                } else {
-                    $off++;
-                }
-                $categories[0]["packs"][] = ["id" => $first_pack->getId(), "label" => $first_pack->getName(), "checked" => $checked, "future" => $first_pack->getDateRelease() === null];
-            } else {
-                $category = ["label" => $cycle->getName(), "packs" => []];
-                foreach ($cycle->getPacks() as $pack) {
-                    $checked = count($packs) ? in_array($pack->getId(), $packs) : true;
-                    if ($checked) {
-                        $on++;
-                    } else {
-                        $off++;
-                    }
-                    $category['packs'][] = ["id" => $pack->getId(), "label" => $pack->getName(), "checked" => $checked, "future" => $pack->getDateRelease() === null];
-                }
-                $categories[] = $category;
-            }
-        }
+        $cycles_and_packs = $this->getCyclesAndPacks($entityManager, is_array($packs) ? $packs : []);
 
         $list_mwl = $entityManager->getRepository('AppBundle:Mwl')->findBy([], ['dateStart' => 'DESC']);
         $list_rotations = $entityManager->getRepository(Rotation::class)->findBy([], ['dateStart' => 'DESC']);
 
         $params = [
-            'allowed'        => $categories,
-            'on'             => $on,
-            'off'            => $off,
-            'author'         => $author_name,
-            'title'          => $decklist_title,
-            'list_mwl'       => $list_mwl,
-            'mwl_code'       => $mwl_code,
-            'list_rotations' => $list_rotations,
-            'rotation_id'    => $rotation_id,
-            'is_legal'       => $is_legal,
+            'cycles_and_packs' => $cycles_and_packs,
+            'author'           => $author_name,
+            'title'            => $decklist_title,
+            'list_mwl'         => $list_mwl,
+            'mwl_code'         => $mwl_code,
+            'list_rotations'   => $list_rotations,
+            'rotation_id'      => $rotation_id,
+            'is_legal'         => $is_legal,
         ];
         $params['sort_' . $sort] = ' selected="selected"';
         if (!empty($faction_code)) {

--- a/src/AppBundle/Service/DecklistManager.php
+++ b/src/AppBundle/Service/DecklistManager.php
@@ -743,9 +743,9 @@ class DecklistManager
         }
 
         if (count($packs)) {
-            $wheres[] = 'not exists(select * from decklistslot join card on decklistslot.card_id=card.id where decklistslot.decklist_id=d.id and card.pack_id not in (?))';
+            $wheres[] = 'not exists(select * from decklistslot join card on decklistslot.card_id=card.id join pack on card.pack_id = pack.id where decklistslot.decklist_id=d.id and pack.code not in (?))';
             $params[] = array_unique($packs);
-            $types[] = Connection::PARAM_INT_ARRAY;
+            $types[] = Connection::PARAM_STR_ARRAY;
         }
         if (!empty($mwl_code)) {
             $wheres[] = 'exists(select * from legality join mwl on legality.mwl_id=mwl.id where legality.decklist_id=d.id and mwl.code=? and legality.is_legal=1)';

--- a/web/js/search.js
+++ b/web/js/search.js
@@ -19,27 +19,12 @@ $(document).on('data.app', function() {
     display: function(card) { return card.title; },
     source: findMatches
   });
-});
 
-function select_only_latest_cards(matchingCards) {
-  var latestCardsByTitle = {};
-  for (var card of matchingCards) {
-    var latestCard = latestCardsByTitle[card.title];
-    if (!latestCard || card.code > latestCard.code) {
-      latestCardsByTitle[card.title] = card;
-    }
-  }
-  return matchingCards.filter(function(value, index, arr) {
-    return value.code == latestCardsByTitle[value.title].code;
+  $('.cycle_checkbox').each(function() {
+    $(this).closest('.checkbox').checklist();
   });
-}
+  handle_checkbox_change();
 
-function handle_checkbox_change() {
-  $('#packs-on').text($('#allowed_packs').find('input[type="checkbox"]:checked').length);
-  $('#packs-off').text($('#allowed_packs').find('input[type="checkbox"]:not(:checked)').length);
-}
-
-$(function() {
   $('#filter-text').on('typeahead:selected typeahead:autocompleted', function(event, card) {
     var line = $(
       '<p class="background-' + card.faction_code +
@@ -57,6 +42,38 @@ $(function() {
 
   $('#allowed_packs').on('change', handle_checkbox_change);
 
+  let rotated_cycles = Array();
+  rotated_cycles['draft'] = 1;
+  rotated_cycles['napd'] = 1;
+  NRDB.data.cycles.find( { "rotated": true } ).forEach(function(cycle) { rotated_cycles[cycle.code] = 1; });
+
+  var startup_cycles = Array();
+  startup_cycles['ashes'] = 1;
+  startup_cycles['system-gateway'] = 1;
+  startup_cycles['system-update-2021'] = 1;
+  var rotated_packs = Array();
+  var startup_packs = Array();
+  NRDB.data.packs.find().forEach(function(pack) {
+    if (rotated_cycles[pack.cycle.code]) { rotated_packs[pack.code] = 1; }
+    if (startup_cycles[pack.cycle.code]) { startup_packs[pack.code] = 1; }
+  });
+
+  $('#select_startup').on('click', function (event) {
+    $('#allowed_packs').find('input[type="checkbox"]').each(function() {
+      $(this).prop('checked', Boolean(startup_cycles[this.value] || startup_packs[this.value]));
+    });
+    handle_checkbox_change();
+    return false;
+  });
+
+  $('#select_standard').on('click', function (event) {
+    $('#allowed_packs').find('input[type="checkbox"]').each(function() {
+      $(this).prop('checked', Boolean(!(rotated_cycles[this.value] || rotated_packs[this.value])));
+    });
+    handle_checkbox_change();
+    return false;
+  });
+
   $('#select_all').on('click', function (event) {
     $('#allowed_packs').find('input[type="checkbox"]:not(:checked)').prop('checked', true);
     handle_checkbox_change();
@@ -69,3 +86,21 @@ $(function() {
     return false;
   });
 });
+
+function select_only_latest_cards(matchingCards) {
+  var latestCardsByTitle = {};
+  for (var card of matchingCards) {
+    var latestCard = latestCardsByTitle[card.title];
+    if (!latestCard || card.code > latestCard.code) {
+      latestCardsByTitle[card.title] = card;
+    }
+  }
+  return matchingCards.filter(function(value, index, arr) {
+    return value.code == latestCardsByTitle[value.title].code;
+  });
+}
+
+function handle_checkbox_change() {
+  $('#packs-on').text($('#allowed_packs').find('input[type="checkbox"]:not(.cycle_checkbox):checked').length + ' on / ');
+  $('#packs-off').text($('#allowed_packs').find('input[type="checkbox"]:not(.cycle_checkbox):not(:checked)').length + ' off');
+}


### PR DESCRIPTION
Add Startup, Standard, All and None options to the packs selection for the decklist search.

![Screenshot 2021-04-14 5 34 15 PM](https://user-images.githubusercontent.com/396562/114789002-0dd1ee00-9d48-11eb-8656-95aff8d8660c.png)
