### PR TITLE
Show which cards are rotated in deckbuilder

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -199,6 +199,11 @@ tbody .btn-group{white-space:nowrap}
 #table-draw-simulator-content div.card-proxy div{position: relative;top: 50%; transform: translateY(-50%);text-align:center}
 #draw-simulator-special {display: none;}
 
+.builder-legality-indicators {
+  display: inline-block;
+  margin: 0 5px 0 2px;
+}
+
 .twitter-typeahead{width:100%}
 .twitter-typeahead .tt-hint{color:#aaa;margin-left:11px;margin-top:4px}
 
@@ -607,4 +612,3 @@ ul.rulings-list blockquote {
     content: "";
   }
 }
-

--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -258,20 +258,40 @@ function find_identity() {
 }
 
 /**
- * Returns a banned or restricted icon for the supplied card and selected MWL.
+ * Returns a banned, restricted, or rotated icon for the supplied card and selected MWL.
  * @param  card
  * @return string
  */
 function unicorn(card) {
     var mwlCard = get_mwl_modified_card(card);
 
+    var result = [];
+
+    function add_icon(icon, description) {
+        result.push('<span title="' + description + '" style="display:inline-block;width:1.5em;">' + icon + '</span>');
+    }
+
+    // Check MWL
     if (mwlCard.is_restricted) {
-        return ' <span title="Restricted card" style="display:inline-block;width:1.5em;">🦄</span> ';
+        add_icon('🦄', 'Restricted card');
     } else if (mwlCard.deck_limit == 0) {
         // Prohibited or banned cards are identified by having a deck_limit of 0.
-        return ' <span title="Banned card" style="display:inline-block;width:1.5em;">🚫</span> ';
+        add_icon('🚫', 'Banned card');
     }
-    return "";
+
+    // Check if set has rotated
+    if (NRDB.settings && NRDB.settings.getItem('check-rotation')) {
+        var rotated_cycles = _.map(NRDB.data.cycles.find( { "rotated": true } ), 'code');
+        var cycle = card.pack.cycle_code;
+        if (rotated_cycles.indexOf(cycle) !== -1) {
+            add_icon('🔁', 'Rotated card');
+        }
+    }
+
+    if (result.length) {
+        return ' ' + result.join('') + ' ';
+    }
+    return '';
 }
 
 function update_deck(options) {

--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -268,7 +268,7 @@ function unicorn(card) {
     var result = [];
 
     function add_icon(icon, description) {
-        result.push('<span title="' + description + '" style="display:inline-block;width:1.5em;">' + icon + '</span>');
+        result.push('<span title="' + description + '">' + icon + '</span>');
     }
 
     // Check MWL
@@ -284,12 +284,12 @@ function unicorn(card) {
         var rotated_cycles = _.map(NRDB.data.cycles.find( { "rotated": true } ), 'code');
         var cycle = card.pack.cycle_code;
         if (rotated_cycles.indexOf(cycle) !== -1) {
-            add_icon('🔁', 'Rotated card');
+            add_icon('🔄', 'Rotated card');
         }
     }
 
     if (result.length) {
-        return ' ' + result.join('') + ' ';
+        return ' <span class="builder-legality-indicators">' + result.join(' ') + '</span> ';
     }
     return '';
 }

--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -262,7 +262,7 @@ function find_identity() {
  * @param  card
  * @return string
  */
-function unicorn(card) {
+function get_card_legality_icons(card) {
     var mwlCard = get_mwl_modified_card(card);
 
     var result = [];
@@ -367,7 +367,7 @@ function update_deck(options) {
     var cabinet = {};
     var parts = Identity.title.split(/: /);
 
-    $('#identity').html('<a href="' + Routing.generate('cards_zoom', { card_code: Identity.code }) + '" data-target="#cardModal" data-remote="false" class="card" data-toggle="modal" data-index="' + Identity.code + '">' + parts[0] + ' <small>' + parts[1] + '</small></a>' + unicorn(Identity));
+    $('#identity').html('<a href="' + Routing.generate('cards_zoom', { card_code: Identity.code }) + '" data-target="#cardModal" data-remote="false" class="card" data-toggle="modal" data-index="' + Identity.code + '">' + parts[0] + ' <small>' + parts[1] + '</small></a>' + get_card_legality_icons(Identity));
     $('#img_identity').prop('src', '/card_image/medium/' + Identity.code + '.jpg');
     InfluenceLimit = Identity.influence_limit;
     if (InfluenceLimit == null || InfluenceLimit == 0)
@@ -471,7 +471,7 @@ function update_deck(options) {
             additional_info = '(<span class="small icon icon-' + card.pack.cycle.code + '"></span> ' + card.position + ') ' + alert_number_of_sets + influence;
         }
 
-        var item = $('<div>' + card.indeck + 'x <a href="' + Routing.generate('cards_zoom', { card_code: card.code }) + '" class="card" data-toggle="modal" data-remote="false" data-target="#cardModal" data-index="' + card.code + '">' + card.title + '</a>' + unicorn(card) + additional_info + '</div>');
+        var item = $('<div>' + card.indeck + 'x <a href="' + Routing.generate('cards_zoom', { card_code: card.code }) + '" class="card" data-toggle="modal" data-remote="false" data-target="#cardModal" data-index="' + card.code + '">' + card.title + '</a>' + get_card_legality_icons(card) + additional_info + '</div>');
         item.appendTo($('#deck-content .deck-' + criteria));
 
         cabinet[criteria] |= 0;


### PR DESCRIPTION
Instead of strugging to figure out which individual cards are rotated, now it just shows in the builder next to the card.

![image](https://user-images.githubusercontent.com/28467304/115100259-a0b09980-9f8f-11eb-9c62-8f88a409b4ac.png)

(Please forgive me for not having card images downloaded in my test environment.)

Notes:

- Is `🔄` or `🔁` the right symbol to use for rotated?
- This code should, in theory, show two icons if a card is rotated _and_ banned. In the picture you can see Security Leak (a Current) is not doing this for some reason. `MWL` in the browser console is `null`, so I think the code does actually work and it failed to load the banlist somehow? I'm still not familiar enough with the system to know what's happening here.