### PR TITLE
Add banlist 21.06 support.

### DIFF
--- a/src/AppBundle/Controller/BanlistsController.php
+++ b/src/AppBundle/Controller/BanlistsController.php
@@ -35,7 +35,8 @@ class BanlistsController extends Controller
             'standard-ban-list-20-06' => true,
             'standard-ban-list-20-09' => true,
             'standard-ban-list-21-04' => true,
-            'standard-ban-list-21-05' => true
+            'standard-ban-list-21-05' => true,
+            'standard-ban-list-21-06' => true,
         ];
 
         foreach ($mwls as $mwl) {


### PR DESCRIPTION
this is needed to support the "currents" ban until we update the JSON to specify all cards of a given type.