### PR TITLE
Add setting to allow unlimited copies of cards

### DIFF
--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -304,8 +304,8 @@ var Filters = {},
       </fieldset>
       <fieldset>
         <div class="radio"><label><input type="radio" name="card-limits" value="legal" data-persistence> Legal limit</label></div>
-        <div class="radio"><label><input type="radio" name="card-limits" value="ignore" data-persistence> Ignore card limits (casual play)</label></div>
-        <div class="radio"><label><input type="radio" name="card-limits" value="max" data-persistence> Maximum 9 (casual play)</label></div>
+        <div class="radio"><label><input type="radio" name="card-limits" value="ignore" data-persistence> Ignore card limits (casual/draft)</label></div>
+        <div class="radio"><label><input type="radio" name="card-limits" value="max" data-persistence> Maximum 9 (casual/draft)</label></div>
       </fieldset>
     </div>
   </div>

--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -303,7 +303,7 @@ var Filters = {},
           <br>
         </fieldset>
         <fieldset class="col-md-6">
-          <label>Card text limits</label>
+          <label>Card limits</label>
           <div class="radio"><label><input type="radio" name="card-limits" value="legal" data-persistence> Legal limit</label></div>
           <div class="radio"><label><input type="radio" name="card-limits" value="ignore" data-persistence> Ignore printed limits (casual play)</label></div>
           <div class="radio"><label><input type="radio" name="card-limits" value="max" data-persistence> Maximum 9 (casual play)</label></div>

--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -270,43 +270,59 @@ var Filters = {},
     </div>
     <!-- tabpanel Settings -->
     <div role="tabpanel" class="tab-pane" id="tab-pane-settings">
-      <fieldset>
-        <div class="checkbox"><label><input type="checkbox" name="show-disabled" data-persistence> Show unusable cards</label></div>
-        <div class="checkbox"><label><input type="checkbox" name="only-deck" data-persistence> Show only used cards</label></div>
-        <div class="checkbox"><label><input type="checkbox" name="show-onesies" data-persistence> Show 1.1.1.1 format compliance</label></div>
-        <div class="checkbox"><label><input type="checkbox" name="show-cacherefresh" data-persistence> Show Cache Refresh format compliance</label></div>
-        <div class="checkbox"><label><input type="checkbox" name="check-rotation" data-persistence> Check for Rotation compliance</label></div>
-      </fieldset>
-      <fieldset>
-        <div class="radio"><label><input type="radio" name="display-columns" value="1" data-persistence> Display on 1 column</label></div>
-        <div class="radio"><label><input type="radio" name="display-columns" value="2" data-persistence> Display on 2 columns</label></div>
-        <div class="radio"><label><input type="radio" name="display-columns" value="3" data-persistence> Display on 3 columns</label></div>
-      </fieldset>
-      <fieldset>
-        <div class="radio"><label><input type="radio" name="core-sets" value="1" data-persistence> Use 1 Core Set</label></div>
-        <div class="radio"><label><input type="radio" name="core-sets" value="2" data-persistence> Use 2 Core Sets</label></div>
-        <div class="radio"><label><input type="radio" name="core-sets" value="3" data-persistence> Use 3 Core Sets</label></div>
-      </fieldset>
-      <fieldset>
-        <div class="radio"><label><input type="radio" name="show-suggestions" value="0" data-persistence> Show no suggestions</label></div>
-        <div class="radio"><label><input type="radio" name="show-suggestions" value="3" data-persistence>Show 3 suggestions</label></div>
-        <div class="radio"><label><input type="radio" name="show-suggestions" value="10" data-persistence> Show 10 suggestions</label></div>
-      </fieldset>
-      <fieldset>
-        <div class="radio"><label><input type="radio" name="buttons-behavior" value="cumulative" data-persistence> Faction/type cumulative</label></div>
-        <div class="radio"><label><input type="radio" name="buttons-behavior" value="exclusive" data-persistence> Faction/type exclusive</label></div>
-      </fieldset>
-      <fieldset>
-        <div class="radio"><label><input type="radio" name="sort-order" value="type" data-persistence> Sort by Type</label></div>
-        <div class="radio"><label><input type="radio" name="sort-order" value="number" data-persistence> Sort by Set</label></div>
-        <div class="radio"><label><input type="radio" name="sort-order" value="faction" data-persistence> Sort by Faction</label></div>
-        <div class="radio"><label><input type="radio" name="sort-order" value="title" data-persistence> Sort by Name</label></div>
-      </fieldset>
-      <fieldset>
-        <div class="radio"><label><input type="radio" name="card-limits" value="legal" data-persistence> Legal limit</label></div>
-        <div class="radio"><label><input type="radio" name="card-limits" value="ignore" data-persistence> Ignore card limits (casual/draft)</label></div>
-        <div class="radio"><label><input type="radio" name="card-limits" value="max" data-persistence> Maximum 9 (casual/draft)</label></div>
-      </fieldset>
+      <div class="row">
+        <fieldset class="col-md-12">
+          <div class="checkbox"><label><input type="checkbox" name="show-disabled" data-persistence> Show unusable cards</label></div>
+          <div class="checkbox"><label><input type="checkbox" name="only-deck" data-persistence> Show only used cards</label></div>
+          <div class="checkbox"><label><input type="checkbox" name="show-onesies" data-persistence> Show 1.1.1.1 format compliance</label></div>
+          <div class="checkbox"><label><input type="checkbox" name="show-cacherefresh" data-persistence> Show Cache Refresh format compliance</label></div>
+          <div class="checkbox"><label><input type="checkbox" name="check-rotation" data-persistence> Check for Rotation compliance</label></div>
+          <br>
+        </fieldset>
+      </div>
+      <div class="row">
+        <fieldset class="col-md-6 padding-bottom-md">
+          <label>Column display</label>
+          <div class="radio"><label><input type="radio" name="display-columns" value="1" data-persistence> Display on 1 column</label></div>
+          <div class="radio"><label><input type="radio" name="display-columns" value="2" data-persistence> Display on 2 columns</label></div>
+          <div class="radio"><label><input type="radio" name="display-columns" value="3" data-persistence> Display on 3 columns</label></div>
+          <br>
+        </fieldset>
+        <fieldset class="col-md-6">
+          <label>Card suggestions</label>
+          <div class="radio"><label><input type="radio" name="show-suggestions" value="0" data-persistence> Show no suggestions</label></div>
+          <div class="radio"><label><input type="radio" name="show-suggestions" value="3" data-persistence>Show 3 suggestions</label></div>
+          <div class="radio"><label><input type="radio" name="show-suggestions" value="10" data-persistence> Show 10 suggestions</label></div>
+          <br>
+        </fieldset>
+        <fieldset class="col-md-6">
+          <label>Core Set limits</label>
+          <div class="radio"><label><input type="radio" name="core-sets" value="1" data-persistence> Use 1 Core Set</label></div>
+          <div class="radio"><label><input type="radio" name="core-sets" value="2" data-persistence> Use 2 Core Sets</label></div>
+          <div class="radio"><label><input type="radio" name="core-sets" value="3" data-persistence> Use 3 Core Sets</label></div>
+          <br>
+        </fieldset>
+        <fieldset class="col-md-6">
+          <label>Card text limits</label>
+          <div class="radio"><label><input type="radio" name="card-limits" value="legal" data-persistence> Legal limit</label></div>
+          <div class="radio"><label><input type="radio" name="card-limits" value="ignore" data-persistence> Ignore printed limits (casual play)</label></div>
+          <div class="radio"><label><input type="radio" name="card-limits" value="max" data-persistence> Maximum 9 (casual play)</label></div>
+          <br>
+        </fieldset>
+          <fieldset class="col-md-6">
+            <label>Sort cards</label>
+            <div class="radio"><label><input type="radio" name="sort-order" value="type" data-persistence> Sort by Type</label></div>
+            <div class="radio"><label><input type="radio" name="sort-order" value="number" data-persistence> Sort by Set</label></div>
+            <div class="radio"><label><input type="radio" name="sort-order" value="faction" data-persistence> Sort by Faction</label></div>
+            <div class="radio"><label><input type="radio" name="sort-order" value="title" data-persistence> Sort by Name</label></div>
+            <br>
+          </fieldset>
+          <fieldset class="col-md-6">
+            <label>Faction/type controls</label>
+            <div class="radio"><label><input type="radio" name="buttons-behavior" value="cumulative" data-persistence> Cumulative</label></div>
+            <div class="radio"><label><input type="radio" name="buttons-behavior" value="exclusive" data-persistence> Exclusive</label></div>
+          </fieldset>
+      </div>
     </div>
   </div>
 

--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -268,20 +268,21 @@ var Filters = {},
     </div>
     <!-- tabpanel Settings -->
     <div role="tabpanel" class="tab-pane" id="tab-pane-settings">
-        <fieldset>
-          <div class="checkbox"><label><input type="checkbox" name="show-disabled" data-persistence> Show unusable cards</label></div>
-          <div class="checkbox"><label><input type="checkbox" name="only-deck" data-persistence> Show only used cards</label></div>
-      <div class="checkbox"><label><input type="checkbox" name="show-onesies" data-persistence> Show 1.1.1.1 format compliance</label></div>
-      <div class="checkbox"><label><input type="checkbox" name="show-cacherefresh" data-persistence> Show Cache Refresh format compliance</label></div>
-            <div class="checkbox"><label><input type="checkbox" name="check-rotation" data-persistence> Check for Rotation compliance</label></div>
-      </fieldset>
-        <fieldset>
-          <div class="radio"><label><input type="radio" name="display-columns" value="1" data-persistence> Display on 1 column</label></div>
-          <div class="radio"><label><input type="radio" name="display-columns" value="2" data-persistence> Display on 2 columns</label></div>
-          <div class="radio"><label><input type="radio" name="display-columns" value="3" data-persistence> Display on 3 columns</label></div>
-        </fieldset>
       <fieldset>
-          <div class="radio"><label><input type="radio" name="core-sets" value="1" data-persistence> Use 1 Core Set</label></div>
+        <div class="checkbox"><label><input type="checkbox" name="show-disabled" data-persistence> Show unusable cards</label></div>
+        <div class="checkbox"><label><input type="checkbox" name="only-deck" data-persistence> Show only used cards</label></div>
+        <div class="checkbox"><label><input type="checkbox" name="ignore-limited-copies" data-persistence> Ignore limited copies text (for casual play)</label></div>
+        <div class="checkbox"><label><input type="checkbox" name="show-onesies" data-persistence> Show 1.1.1.1 format compliance</label></div>
+        <div class="checkbox"><label><input type="checkbox" name="show-cacherefresh" data-persistence> Show Cache Refresh format compliance</label></div>
+        <div class="checkbox"><label><input type="checkbox" name="check-rotation" data-persistence> Check for Rotation compliance</label></div>
+      </fieldset>
+      <fieldset>
+        <div class="radio"><label><input type="radio" name="display-columns" value="1" data-persistence> Display on 1 column</label></div>
+        <div class="radio"><label><input type="radio" name="display-columns" value="2" data-persistence> Display on 2 columns</label></div>
+        <div class="radio"><label><input type="radio" name="display-columns" value="3" data-persistence> Display on 3 columns</label></div>
+      </fieldset>
+      <fieldset>
+        <div class="radio"><label><input type="radio" name="core-sets" value="1" data-persistence> Use 1 Core Set</label></div>
         <div class="radio"><label><input type="radio" name="core-sets" value="2" data-persistence> Use 2 Core Sets</label></div>
         <div class="radio"><label><input type="radio" name="core-sets" value="3" data-persistence> Use 3 Core Sets</label></div>
       </fieldset>

--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -273,7 +273,6 @@ var Filters = {},
       <fieldset>
         <div class="checkbox"><label><input type="checkbox" name="show-disabled" data-persistence> Show unusable cards</label></div>
         <div class="checkbox"><label><input type="checkbox" name="only-deck" data-persistence> Show only used cards</label></div>
-        <div class="checkbox"><label><input type="checkbox" name="ignore-limited-copies" data-persistence> Ignore limited copies text (for casual play)</label></div>
         <div class="checkbox"><label><input type="checkbox" name="show-onesies" data-persistence> Show 1.1.1.1 format compliance</label></div>
         <div class="checkbox"><label><input type="checkbox" name="show-cacherefresh" data-persistence> Show Cache Refresh format compliance</label></div>
         <div class="checkbox"><label><input type="checkbox" name="check-rotation" data-persistence> Check for Rotation compliance</label></div>
@@ -302,6 +301,11 @@ var Filters = {},
         <div class="radio"><label><input type="radio" name="sort-order" value="number" data-persistence> Sort by Set</label></div>
         <div class="radio"><label><input type="radio" name="sort-order" value="faction" data-persistence> Sort by Faction</label></div>
         <div class="radio"><label><input type="radio" name="sort-order" value="title" data-persistence> Sort by Name</label></div>
+      </fieldset>
+      <fieldset>
+        <div class="radio"><label><input type="radio" name="card-limits" value="legal" data-persistence> Legal limit</label></div>
+        <div class="radio"><label><input type="radio" name="card-limits" value="ignore" data-persistence> Ignore card limits (casual play)</label></div>
+        <div class="radio"><label><input type="radio" name="card-limits" value="max" data-persistence> Maximum 9 (casual play)</label></div>
       </fieldset>
     </div>
   </div>

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -158,7 +158,7 @@ Promise.all([NRDB.data.promise, NRDB.settings.promise]).then(function() {
     case 'only-deck':
       refresh_collection();
       break;
-    case 'ignore-limited-copies':
+    case 'card-limits':
       refresh_collection(true);
       break;
     case 'show-suggestions':
@@ -754,19 +754,18 @@ function build_div(record) {
     influ += "●";
   }
 
-  /**
-   * This controls the true value of how many copies of a card can be in a deck.
-   * maxqty is normally 3, and is X for cards with text "limit X per deck".
-   * However, if somebody wants to use an illegal number of copies for casual play,
-   * a setting in the builder can increase this up to 3.
-   */
-  var pref_extended_maxqty = record.maxqty;
-  if (NRDB.settings && NRDB.settings.getItem("ignore-limited-copies")) { // if the setting is enabled,
-    pref_extended_maxqty = Math.max(pref_extended_maxqty, 3); // increase allowed copies up to 3.
+  var max_qty = record.maxqty;
+  switch (NRDB.settings.getItem("card-limits")) {
+  case "ignore":
+    max_qty = Math.max(3, max_qty);
+    break;
+  case "max":
+    max_qty = 9;
+    break;
   }
 
   var radios = '';
-  for (var i = 0; i <= pref_extended_maxqty; i++) {
+  for (var i = 0; i <= max_qty; i++) {
     if (i && !(i % 4)) {
       radios += '<br>';
     }

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -755,13 +755,15 @@ function build_div(record) {
   }
 
   var max_qty = record.maxqty;
-  switch (NRDB.settings.getItem("card-limits")) {
-  case "ignore":
-    max_qty = Math.max(3, max_qty);
-    break;
-  case "max":
-    max_qty = 9;
-    break;
+  if (record.type.code != 'identity') {
+    switch (NRDB.settings.getItem("card-limits")) {
+    case "ignore":
+      max_qty = Math.max(3, max_qty);
+      break;
+    case "max":
+      max_qty = 9;
+      break;
+    }
   }
 
   var radios = '';

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -12,10 +12,6 @@ function update_max_qty() {
     if(card.pack_code == 'core' || card.pack_code == 'core2' || card.pack_code == 'sc19') {
       max_qty = Math.min(card.quantity * NRDB.settings.getItem('core-sets'), max_qty);
     }
-    const draft_packs = ["draft"];
-    if(draft_packs.includes(Identity.pack_code)) {
-      max_qty = 9;
-    }
     if (max_qty > 0) {
       // Nova Initiumia & Ampere only allow a max of 1 copy per card.
       if (Identity.code == '33093' || Identity.code == '33128') {
@@ -726,10 +722,6 @@ function update_core_sets() {
   }).forEach(function(card) {
         var modifiedCard = get_mwl_modified_card(card);
     var max_qty = Math.min(card.quantity * NRDB.settings.getItem('core-sets'), modifiedCard.deck_limit);
-    const draft_packs = ["draft"];
-    if(draft_packs.includes(Identity.pack_code)) {
-      max_qty = 9;
-    }
     NRDB.data.cards.updateById(card.code, {
       maxqty : max_qty
     });

--- a/web/js/nrdb.card_modal.js
+++ b/web/js/nrdb.card_modal.js
@@ -35,13 +35,15 @@
     if(qtyelt && typeof Filters != "undefined") {
 
       var max_qty = card.maxqty;
-      switch (NRDB.settings.getItem("card-limits")) {
-      case "ignore":
-        max_qty = Math.max(3, max_qty);
-        break;
-      case "max":
-        max_qty = 9;
-        break;
+      if (card.type.code != 'identity') {
+        switch (NRDB.settings.getItem("card-limits")) {
+        case "ignore":
+          max_qty = Math.max(3, max_qty);
+          break;
+        case "max":
+          max_qty = 9;
+          break;
+        }
       }
 
       var qty = '';

--- a/web/js/nrdb.card_modal.js
+++ b/web/js/nrdb.card_modal.js
@@ -34,13 +34,18 @@
     var qtyelt = modal.find('.modal-qty');
     if(qtyelt && typeof Filters != "undefined") {
 
-      var pref_extended_maxqty = card.maxqty;
-      if (NRDB.settings && NRDB.settings.getItem("ignore-limited-copies")) { // if the setting is enabled,
-        pref_extended_maxqty = Math.max(pref_extended_maxqty, 3); // increase allowed copies up to 3.
+      var max_qty = card.maxqty;
+      switch (NRDB.settings.getItem("card-limits")) {
+      case "ignore":
+        max_qty = Math.max(3, max_qty);
+        break;
+      case "max":
+        max_qty = 9;
+        break;
       }
 
       var qty = '';
-      for(var i=0; i<=pref_extended_maxqty; i++) {
+      for(var i=0; i<=max_qty; i++) {
         qty += '<label class="btn btn-default"><input type="radio" name="qty" value="'+i+'">'+i+'</label>';
       }
       qtyelt.html(qty);

--- a/web/js/nrdb.card_modal.js
+++ b/web/js/nrdb.card_modal.js
@@ -34,13 +34,18 @@
     var qtyelt = modal.find('.modal-qty');
     if(qtyelt && typeof Filters != "undefined") {
 
-      var qty = '';
-        for(var i=0; i<=card.maxqty; i++) {
-          qty += '<label class="btn btn-default"><input type="radio" name="qty" value="'+i+'">'+i+'</label>';
-        }
-        qtyelt.html(qty);
+      var pref_extended_maxqty = card.maxqty;
+      if (NRDB.settings && NRDB.settings.getItem("ignore-limited-copies")) { // if the setting is enabled,
+        pref_extended_maxqty = Math.max(pref_extended_maxqty, 3); // increase allowed copies up to 3.
+      }
 
-        qtyelt.find('label').each(function (index, element) {
+      var qty = '';
+      for(var i=0; i<=pref_extended_maxqty; i++) {
+        qty += '<label class="btn btn-default"><input type="radio" name="qty" value="'+i+'">'+i+'</label>';
+      }
+      qtyelt.html(qty);
+
+      qtyelt.find('label').each(function (index, element) {
         if(index == card.indeck) $(element).addClass('active');
         else $(element).removeClass('active');
       });

--- a/web/js/nrdb.settings.js
+++ b/web/js/nrdb.settings.js
@@ -4,7 +4,6 @@
   var cache = {
     'show-disabled': false,
     'only-deck': false,
-    'ignore-limited-copies': false,
     'show-onesies': false,
     'show-cacherefresh': false,
     'display-columns': 1,
@@ -12,7 +11,8 @@
     'show-suggestions': 3,
     'buttons-behavior': 'cumulative',
     'sort-order': 'type',
-    'check-rotation': true
+    'check-rotation': true,
+    'card-limits': 'legal'
   };
 
   settings.load = function load() {

--- a/web/js/nrdb.settings.js
+++ b/web/js/nrdb.settings.js
@@ -2,16 +2,17 @@
 
   // all the settings, initialized with their default value
   var cache = {
-      'show-disabled': false,
-      'only-deck': false,
-      'show-onesies': false,
-      'show-cacherefresh': false,
-      'display-columns': 1,
-      'core-sets': 3,
-      'show-suggestions': 3,
-      'buttons-behavior': 'cumulative',
-      'sort-order': 'type',
-            'check-rotation': true
+    'show-disabled': false,
+    'only-deck': false,
+    'ignore-limited-copies': false,
+    'show-onesies': false,
+    'show-cacherefresh': false,
+    'display-columns': 1,
+    'core-sets': 3,
+    'show-suggestions': 3,
+    'buttons-behavior': 'cumulative',
+    'sort-order': 'type',
+    'check-rotation': true
   };
 
   settings.load = function load() {

--- a/web/js/nrdb.suggestions.js
+++ b/web/js/nrdb.suggestions.js
@@ -107,15 +107,21 @@
   suggestions.div = function(card) {
     var faction = card.faction_code;
     var influ = "";
-    for (var i = 0; i < card.factioncost; i++)
+    for (var i = 0; i < card.factioncost; i++) {
       influ += "●";
+    }
+
+    var pref_extended_maxqty = card.maxqty;
+    if (NRDB.settings && NRDB.settings.getItem("ignore-limited-copies")) { // if the setting is enabled,
+      pref_extended_maxqty = Math.max(pref_extended_maxqty, 3); // increase allowed copies up to 3.
+    }
 
     var radios = '';
-    for (var i = 0; i <= card.maxqty; i++) {
+    for (var i = 0; i <= pref_extended_maxqty; i++) {
       radios += '<label class="btn btn-xs btn-default'
-          + (i == card.indeck ? ' active' : '')
-          + '"><input type="radio" name="qty-' + card.code
-          + '" value="' + i + '">' + i + '</label>';
+        + (i == card.indeck ? ' active' : '')
+        + '"><input type="radio" name="qty-' + card.code
+        + '" value="' + i + '">' + i + '</label>';
     }
 
     var imgsrc = card.faction_code.substr(0,7) === "neutral" ? "" : '<img data-src="'

--- a/web/js/nrdb.suggestions.js
+++ b/web/js/nrdb.suggestions.js
@@ -111,14 +111,16 @@
       influ += "●";
     }
 
-    var max_qty = record.maxqty;
-    switch (NRDB.settings.getItem("card-limits")) {
-    case "ignore":
-      max_qty = Math.max(3, max_qty);
-      break;
-    case "max":
-      max_qty = 9;
-      break;
+    var max_qty = card.maxqty;
+    if (card.type.code != 'identity') {
+      switch (NRDB.settings.getItem("card-limits")) {
+      case "ignore":
+        max_qty = Math.max(3, max_qty);
+        break;
+      case "max":
+        max_qty = 9;
+        break;
+      }
     }
 
     var radios = '';

--- a/web/js/nrdb.suggestions.js
+++ b/web/js/nrdb.suggestions.js
@@ -111,13 +111,18 @@
       influ += "●";
     }
 
-    var pref_extended_maxqty = card.maxqty;
-    if (NRDB.settings && NRDB.settings.getItem("ignore-limited-copies")) { // if the setting is enabled,
-      pref_extended_maxqty = Math.max(pref_extended_maxqty, 3); // increase allowed copies up to 3.
+    var max_qty = record.maxqty;
+    switch (NRDB.settings.getItem("card-limits")) {
+    case "ignore":
+      max_qty = Math.max(3, max_qty);
+      break;
+    case "max":
+      max_qty = 9;
+      break;
     }
 
     var radios = '';
-    for (var i = 0; i <= pref_extended_maxqty; i++) {
+    for (var i = 0; i <= max_qty; i++) {
       radios += '<label class="btn btn-xs btn-default'
         + (i == card.indeck ? ' active' : '')
         + '"><input type="radio" name="qty-' + card.code


### PR DESCRIPTION
Someone said they wanted this feature, and it seems like it would be good to add. https://www.reddit.com/r/Netrunner/comments/ooge0a/including_multiple_astroscripts_in_netrunnerdb/

Basically, when enabled in the settings tab, card text like "limit 1 per deck" no longer applies, and 3 copies (or more if the card text says more) can be added to the deck. A warning "too many copies of a limited card" is then shown. This warning was already in the code.

Questionable parts of this code:
- I have not tested card suggestions at all
- The for loop that generates the card count radio buttons is copypasted in 3 places. I'd like to merge them into 1, but not sure where I would put that function, since it needs to be shared across files, and I don't know how you're managing JS imports in netrunnerdb.

I think the rest of my code is all good, though. I tested both the card selection table and the card modal and they're good.

(By the way, [reverting this commit as discussed](https://github.com/NetrunnerDB/netrunnerdb/issues/520#issuecomment-821757580) is still required to create the database.)