### PR TITLE
Add an option for active MWL in get_mwl_info.

### DIFF
--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -55,7 +55,7 @@ class BuilderController extends Controller
         $identities = $cardsData->select_only_latest_cards($identities);
         $banned_cards = array();
         foreach ($identities as $id) {
-            $i = $cardsData->get_mwl_info([$id]);
+            $i = $cardsData->get_mwl_info([$id], true /* active_only */);
             if (count($i) > 0 && $i[array_keys($i)[0]]['active'] && $i[array_keys($i)[0]]['deck_limit'] === 0) {
                 $banned_cards[$id->getCode()] = true;
             }

--- a/src/AppBundle/Controller/FactionController.php
+++ b/src/AppBundle/Controller/FactionController.php
@@ -84,7 +84,7 @@ class FactionController extends Controller
 
                 $identity = $cardsData->select_only_latest_cards($identities);
 
-                $i = $cardsData->get_mwl_info([$identity[0]]);
+                $i = $cardsData->get_mwl_info([$identity[0]], true /* active_only */);
                 if (count($i) > 0 && $i[array_keys($i)[0]]['active'] && $i[array_keys($i)[0]]['deck_limit'] === 0) {
                     $banned_cards[$identity[0]->getCode()] = true;
                 }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -923,10 +923,14 @@ class CardsData
         ));
     }
 
-    public function get_mwl_info(array $cards)
+    public function get_mwl_info(array $cards, bool $active_only = false)
     {
         $response = [];
-        $mwls = $this->entityManager->getRepository(Mwl::class)->findBy([], ["dateStart" => "DESC"]);
+        $filters = [];
+        if ($active_only) {
+            $filters = ["active" => 1];
+        }
+        $mwls = $this->entityManager->getRepository(Mwl::class)->findBy($filters, ["dateStart" => "DESC"]);
 
         foreach ($cards as $card) {
             $card_code = $card->getCode();


### PR DESCRIPTION
This fixes the issue where a new, not-yet-active MWL is pushed and the faction and deckbuilder iD selection pages show nothing as banned. 