### PR TITLE
Add caching to all public API methods except deck.

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -11,6 +11,12 @@ services:
         resource: '../../src/AppBundle/*'
         exclude: '../../src/AppBundle/{Behavior,DataFixtures,DQL,Entity,Repository,Resources}'
 
+    AppBundle\EventListener\DecklistListener:
+        tags:
+            - { name: doctrine.event_listener, entity: AppBundle\Entity\Decklist, event: postPersist }
+            - { name: doctrine.event_listener, entity: AppBundle\Entity\Decklist, event: postUpdate }
+            - { name: doctrine.event_listener, entity: AppBundle\Entity\Decklist, event: postRemove }
+
     FOS\OAuthServerBundle\Entity\ClientManager:
         alias: 'fos_oauth_server.client_manager.default'
 

--- a/src/AppBundle/EventListener/DecklistListener.php
+++ b/src/AppBundle/EventListener/DecklistListener.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace AppBundle\EventListener;
+
+use AppBundle\Entity\Decklist;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+
+class DecklistListener
+{
+    private $logger;
+    private $cache;
+
+    // Since public API requests will cache, even for items that don't exist,
+    // we need to clear the cache if a missing decklist exists now.
+    // Likewise, we need to return fresh data if the source decklist changes.
+    public function __construct(LoggerInterface $logger, AdapterInterface $cache)
+    {
+      $this->logger = $logger;
+      $this->cache = $cache;
+    }
+
+    private function clearFromCache(LifecycleEventArgs $args) {
+      $entity = $args->getObject();
+
+      if (!$entity instanceof Decklist) {
+        return;
+      }
+      $this->cache->deleteItem('public-api-decklist-' . $entity->getId());
+    }
+
+    public function postPersist(LifecycleEventArgs $args)
+    {
+      $this->clearFromCache($args);
+    }
+
+    public function postUpdate(LifecycleEventArgs $args)
+    {
+      $this->clearFromCache($args);
+    }
+
+    public function postRemove(LifecycleEventArgs $args)
+    {
+      $this->clearFromCache($args);
+    }
+}


### PR DESCRIPTION
This takes care of 99% of the requests for the public APIs.

I should be able to change the qps quotas for these requests after this is deployed.  Right now this will use the default filesystem cache, but we should be able to configure it for something faster like memcache or even move the filesystem cache to a ramdisk if we want.

The Listener is needed to handle cache misses for decklists.  For everything else, we already clear the cache when importing new cards or data from the JSON repo.