### PR TITLE
Make pack filter exact, not-partial match.

### DIFF
--- a/web/js/nrdb.smart_filter.js
+++ b/web/js/nrdb.smart_filter.js
@@ -103,7 +103,8 @@
   }
   function add_string_sf(key, operator, values) {
     for (var j = 0; j < values.length; j++) {
-      values[j] = new RegExp(values[j], 'i');
+      // Do exact matches for packs
+      values[j] = key == 'pack_code' ? new RegExp('^(' + values[j] + ')$', 'i') : new RegExp(values[j], 'i');
     }
     switch (operator) {
     case ":":


### PR DESCRIPTION
reported by folks trying to do random access memories deckbuilding.  The bug this fixes was triggered by e:td in the deckbuilder filter, which would return Terminal Directive and the Terminal Directive packs.