### PR TITLE
Add Deck & Decklist UUIDs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "michelf/php-markdown": "^1.8",
         "nelmio/api-doc-bundle": "^2.0",
         "phpstan/phpstan": "^0.9.2",
+        "ramsey/uuid": "^3.9",
         "sensio/distribution-bundle": "^5.0.19",
         "sensio/framework-extra-bundle": "^5.0.0",
         "stof/doctrine-extensions-bundle": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "02033bc172718a915d5e835a0e8e63cb",
+    "content-hash": "19d2e0352e2982fb2003427511518437",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -619,6 +619,7 @@
                 "cache",
                 "caching"
             ],
+            "abandoned": true,
             "time": "2019-11-29T11:22:01+00:00"
         },
         {
@@ -1122,6 +1123,7 @@
                 "reflection",
                 "static"
             ],
+            "abandoned": "roave/better-reflection",
             "time": "2020-01-08T19:53:19+00:00"
         },
         {
@@ -3709,6 +3711,95 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
+            "name": "ramsey/uuid",
+            "version": "3.9.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ramsey/uuid.git",
+                "reference": "ffa80ab953edd85d5b6c004f96181a538aad35a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/ffa80ab953edd85d5b6c004f96181a538aad35a3",
+                "reference": "ffa80ab953edd85d5b6c004f96181a538aad35a3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "paragonie/random_compat": "^1 | ^2 | ^9.99.99",
+                "php": "^5.4 | ^7.0 | ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "replace": {
+                "rhumsaa/uuid": "self.version"
+            },
+            "require-dev": {
+                "codeception/aspect-mock": "^1 | ^2",
+                "doctrine/annotations": "^1.2",
+                "goaop/framework": "1.0.0-alpha.2 | ^1 | >=2.1.0 <=2.3.2",
+                "mockery/mockery": "^0.9.11 | ^1",
+                "moontoast/math": "^1.1",
+                "nikic/php-parser": "<=4.5.0",
+                "paragonie/random-lib": "^2",
+                "php-mock/php-mock-phpunit": "^0.3 | ^1.1 | ^2.6",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpunit/phpunit": ">=4.8.36 <9.0.0 | >=9.3.0",
+                "squizlabs/php_codesniffer": "^3.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-ctype": "Provides support for PHP Ctype functions",
+                "ext-libsodium": "Provides the PECL libsodium extension for use with the SodiumRandomGenerator",
+                "ext-openssl": "Provides the OpenSSL extension for use with the OpenSslGenerator",
+                "ext-uuid": "Provides the PECL UUID extension for use with the PeclUuidTimeGenerator and PeclUuidRandomGenerator",
+                "moontoast/math": "Provides support for converting UUID to 128-bit integer (in string form).",
+                "paragonie/random-lib": "Provides RandomLib for use with the RandomLibAdapter",
+                "ramsey/uuid-console": "A console application for generating UUIDs with ramsey/uuid",
+                "ramsey/uuid-doctrine": "Allows the use of Ramsey\\Uuid\\Uuid as Doctrine field type."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Ramsey",
+                    "email": "ben@benramsey.com",
+                    "homepage": "https://benramsey.com"
+                },
+                {
+                    "name": "Marijn Huizendveld",
+                    "email": "marijn.huizendveld@gmail.com"
+                },
+                {
+                    "name": "Thibaud Fabre",
+                    "email": "thibaud@aztech.io"
+                }
+            ],
+            "description": "Formerly rhumsaa/uuid. A PHP 5.4+ library for generating RFC 4122 version 1, 3, 4, and 5 universally unique identifiers (UUID).",
+            "homepage": "https://github.com/ramsey/uuid",
+            "keywords": [
+                "guid",
+                "identifier",
+                "uuid"
+            ],
+            "time": "2021-09-25T23:07:42+00:00"
+        },
+        {
             "name": "sensio/distribution-bundle",
             "version": "v5.0.25",
             "source": {
@@ -3758,6 +3849,7 @@
                 "configuration",
                 "distribution"
             ],
+            "abandoned": true,
             "time": "2019-06-18T15:43:58+00:00"
         },
         {
@@ -3879,6 +3971,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
+            "abandoned": "https://github.com/fabpot/local-php-security-checker",
             "time": "2019-11-01T13:20:14+00:00"
         },
         {
@@ -3998,6 +4091,7 @@
                 "mail",
                 "mailer"
             ],
+            "abandoned": "symfony/mailer",
             "time": "2018-07-31T09:26:32+00:00"
         },
         {

--- a/src/AppBundle/Command/SetDecklistsUuidCommand.php
+++ b/src/AppBundle/Command/SetDecklistsUuidCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+
+/**
+ * Update UUIDs for any decklists that are missing them. 
+ *
+ * @author Alsciende <alsciende@icloud.com>
+ */
+class SetDecklistsUuidCommand extends ContainerAwareCommand
+{
+    /** @var EntityManagerInterface $entityManager */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+    }
+
+    protected function configure()
+    {
+        $this
+                ->setName('app:uuid:decklists')
+                ->setDescription('Set a UUID for any decklist missing it.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+		$sql = "UPDATE decklist "
+			. "SET uuid = LOWER(CONCAT("
+			. "HEX(RANDOM_BYTES(4)), '-', "
+			. "HEX(RANDOM_BYTES(2)), '-4', "
+			. "SUBSTR(HEX(RANDOM_BYTES(2)), 2, 3), '-', "
+			. "CONCAT(HEX(FLOOR(ASCII(RANDOM_BYTES(1)) / 64)+8), SUBSTR(HEX(RANDOM_BYTES(2)), 2, 3)), "
+			. "'-', HEX(RANDOM_BYTES(6))))"
+			. " WHERE uuid IS NULL";
+
+        $this->entityManager->getConnection()->executeQuery($sql);
+
+        $output->writeln("<info>Done</info>");
+    }
+}

--- a/src/AppBundle/Command/SetDecklistsUuidCommand.php
+++ b/src/AppBundle/Command/SetDecklistsUuidCommand.php
@@ -33,14 +33,28 @@ class SetDecklistsUuidCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-		$sql = "UPDATE decklist "
-			. "SET uuid = LOWER(CONCAT("
-			. "HEX(RANDOM_BYTES(4)), '-', "
-			. "HEX(RANDOM_BYTES(2)), '-4', "
-			. "SUBSTR(HEX(RANDOM_BYTES(2)), 2, 3), '-', "
-			. "CONCAT(HEX(FLOOR(ASCII(RANDOM_BYTES(1)) / 64)+8), SUBSTR(HEX(RANDOM_BYTES(2)), 2, 3)), "
-			. "'-', HEX(RANDOM_BYTES(6))))"
-			. " WHERE uuid IS NULL";
+        // Construct a v4 UUID in SQL according to https://www.ietf.org/rfc/rfc4122.txt
+        $sql = "UPDATE decklist "
+            . "SET uuid = "
+            . "LOWER(CONCAT("
+            // start with random bits
+            . "HEX(RANDOM_BYTES(4)), '-', "
+            . "HEX(RANDOM_BYTES(2)), '-"
+            // v4 has 0100 as the version indicator in bits 6 and 7 of the time_hi_and_version field, so always a 4 in hex.
+            . "4', "
+            // padded out by random bits.
+            . "SUBSTR(HEX(RANDOM_BYTES(2)), 2, 3), '-', "
+            . "CONCAT("
+            // The spec says: Set bits 6 and 7 of the clock_seq_hi_and_reserved value to 10.
+            // which means this next hex value is always one of 8,9,a,or b, which this next bit does in an ugly way.
+            . "HEX(FLOOR(ASCII(RANDOM_BYTES(1)) / 64)+8), "
+            // padded out by random bits.
+            . "SUBSTR(HEX(RANDOM_BYTES(2)), 2, 3)), "
+            // Close it out with more random bits.
+            . "'-', HEX(RANDOM_BYTES(6))"
+            . "))" // LOWER(CONCAT(
+            // Only for decklists missing a UUID already.
+            . " WHERE uuid IS NULL";
 
         $this->entityManager->getConnection()->executeQuery($sql);
 

--- a/src/AppBundle/Command/SetDecksUuidCommand.php
+++ b/src/AppBundle/Command/SetDecksUuidCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+
+/**
+ * Update UUIDs for any decks that are missing them. 
+ *
+ * @author Alsciende <alsciende@icloud.com>
+ */
+class SetDecksUuidCommand extends ContainerAwareCommand
+{
+    /** @var EntityManagerInterface $entityManager */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+    }
+
+    protected function configure()
+    {
+        $this
+                ->setName('app:uuid:decks')
+                ->setDescription('Set a UUID for any deck missing it.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+		$sql = "UPDATE deck "
+			. "SET uuid = LOWER(CONCAT("
+			. "HEX(RANDOM_BYTES(4)), '-', "
+			. "HEX(RANDOM_BYTES(2)), '-4', "
+			. "SUBSTR(HEX(RANDOM_BYTES(2)), 2, 3), '-', "
+			. "CONCAT(HEX(FLOOR(ASCII(RANDOM_BYTES(1)) / 64)+8), SUBSTR(HEX(RANDOM_BYTES(2)), 2, 3)), "
+			. "'-', HEX(RANDOM_BYTES(6))))"
+			. " WHERE uuid IS NULL";
+
+        $this->entityManager->getConnection()->executeQuery($sql);
+
+        $output->writeln("<info>Done</info>");
+    }
+}

--- a/src/AppBundle/Controller/PublicApi20Controller.php
+++ b/src/AppBundle/Controller/PublicApi20Controller.php
@@ -400,10 +400,29 @@ class PublicApi20Controller extends FOSRestController
      * )
      *
      */
-    public function decklistAction(int $decklist_id, Request $request)
+    public function decklistByIdAction(int $decklist_id, Request $request)
     {
       return $this->getSingleEntityFromCache("public-api-decklist-" . $decklist_id, function() use ($decklist_id) {
         return $this->entityManager->getRepository('AppBundle:Decklist')->findOneBy(['id' => $decklist_id]);
+      }, $request);
+    }
+
+    /**
+     * Get a decklist by UUID
+     *
+     * @ApiDoc(
+     *  section="Decklist",
+     *  resource=true,
+     *  description="Get one (published) decklist",
+     *  parameters={
+     *  },
+     * )
+     *
+     */
+    public function decklistByUuidAction(string $uuid, Request $request)
+    {
+      return $this->getSingleEntityFromCache("public-api-decklist-" . $uuid, function() use ($uuid) {
+        return $this->entityManager->getRepository('AppBundle:Decklist')->findOneBy(['uuid' => $uuid]);
       }, $request);
     }
 
@@ -453,7 +472,30 @@ class PublicApi20Controller extends FOSRestController
      *
      * @ParamConverter("deck", class="AppBundle:Deck", options={"id" = "deck_id"})
      */
-    public function deckAction(Deck $deck, Request $request)
+    public function deckByIdAction(Deck $deck, Request $request)
+    {
+        // Not currently caching because this is currently very rarely used.
+        if (!$deck->getUser()->getShareDecks()) {
+          throw $this->createAccessDeniedException();
+        }
+
+        return $this->prepareResponse([$deck], $request);
+    }
+
+    /**
+     * Get a deck by UUID
+     *
+     * @ApiDoc(
+     *  section="Deck",
+     *  resource=true,
+     *  description="Get one (private, shared) deck",
+     *  parameters={
+     *  },
+     * )
+     *
+     * @ParamConverter("deck", class="AppBundle:Deck", options={"mapping": {"uuid": "uuid"}})
+     */
+    public function deckByUuidAction(Deck $deck, Request $request)
     {
         // Not currently caching because this is currently very rarely used.
         if (!$deck->getUser()->getShareDecks()) {

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -3,35 +3,38 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Entity\Card;
+use AppBundle\Entity\Comment;
+use AppBundle\Entity\Deck;
+use AppBundle\Entity\Decklist;
+use AppBundle\Entity\Decklistslot;
 use AppBundle\Entity\Deckslot;
+use AppBundle\Entity\Legality;
 use AppBundle\Entity\Tournament;
+use AppBundle\Entity\User;
 use AppBundle\Service\ActivityHelper;
+use AppBundle\Service\CardsData;
 use AppBundle\Service\DecklistManager;
 use AppBundle\Service\Judge;
 use AppBundle\Service\ModerationHelper;
 use AppBundle\Service\RotationService;
 use AppBundle\Service\TextProcessor;
 use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Response;
-use AppBundle\Entity\Deck;
-use AppBundle\Entity\Decklist;
-use AppBundle\Entity\Decklistslot;
-use AppBundle\Entity\Comment;
-use AppBundle\Entity\User;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use AppBundle\Entity\Legality;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use AppBundle\Service\CardsData;
 
 class SocialController extends Controller
 {
 
     /**
+     * This function is used to check if a deck can be published from the deck list page.
+     *
      * @param Deck $deck
      * @param EntityManagerInterface $entityManager
      * @param Judge                  $judge
@@ -131,6 +134,10 @@ class SocialController extends Controller
         $tournament = $entityManager->getRepository('AppBundle:Tournament')->find($tournament_id);
 
         $decklist = new Decklist();
+        // Note: We are doing the naive thing and just assuming we won't collide.
+		// If there is a collision, there will be an error returned to the user.
+		// Sorry, users!  v2 will be nicer to you!
+        $decklist->setUuid(Uuid::uuid4()->toString());
         $decklist->setName($name);
         $decklist->setPrettyname(preg_replace('/[^a-z0-9]+/', '-', mb_strtolower($name)));
         $decklist->setRawdescription($rawdescription);
@@ -881,6 +888,12 @@ class SocialController extends Controller
             }
         }
 
+        // Note: We are doing the naive thing and just assuming we won't collide.
+		// If there is a collision, there will be an error returned to the user.
+		// Sorry, users!  v2 will be nicer to you!
+        if ($decklist->getUuid() == null) {
+            $decklist->setUuid(Uuid::uuid4()->toString());
+        }
         $decklist->setName($name);
         $decklist->setPrettyname(preg_replace('/[^a-z0-9]+/', '-', mb_strtolower($name)));
         $decklist->setRawdescription($rawdescription);

--- a/src/AppBundle/Entity/Deck.php
+++ b/src/AppBundle/Entity/Deck.php
@@ -18,6 +18,11 @@ class Deck implements NormalizableInterface, TimestampableInterface
     private $id;
 
     /**
+     * @var string|null
+     */
+    private $uuid;
+
+    /**
      * @var string
      */
     private $name;
@@ -141,6 +146,7 @@ class Deck implements NormalizableInterface, TimestampableInterface
 
         return [
             'id'            => $this->id,
+            'uuid'          => $this->uuid,
             'date_creation' => $this->dateCreation->format('c'),
             'date_update'   => $this->dateUpdate->format('c'),
             'name'          => $this->name,
@@ -157,6 +163,25 @@ class Deck implements NormalizableInterface, TimestampableInterface
     public function getId()
     {
         return $this->id;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * @param string $uuid
+     * @return $this
+     */
+    public function setUuid(string $uuid)
+    {
+        $this->uuid = $uuid;
+
+        return $this;
     }
 
     /**

--- a/src/AppBundle/Entity/Decklist.php
+++ b/src/AppBundle/Entity/Decklist.php
@@ -23,6 +23,11 @@ class Decklist implements NormalizableInterface, TimestampableInterface
     private $id;
 
     /**
+     * @var string|null
+     */
+    private $uuid;
+
+    /**
      * @var \DateTime
      */
     private $dateUpdate;
@@ -207,6 +212,7 @@ class Decklist implements NormalizableInterface, TimestampableInterface
 
         return [
             'id'               => $this->id,
+            'uuid'             => $this->uuid,
             'date_creation'    => $this->dateCreation->format('c'),
             'date_update'      => $this->dateUpdate->format('c'),
             'name'             => $this->name,
@@ -242,6 +248,25 @@ class Decklist implements NormalizableInterface, TimestampableInterface
     public function setDateUpdate(\DateTime $dateUpdate)
     {
         $this->dateUpdate = $dateUpdate;
+
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * @param string $uuid
+     * @return $this
+     */
+    public function setUuid(string $uuid)
+    {
+        $this->uuid = $uuid;
 
         return $this;
     }

--- a/src/AppBundle/Resources/config/doctrine/Deck.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Deck.orm.yml
@@ -65,6 +65,11 @@ AppBundle\Entity\Deck:
             id: true
             generator:
                 strategy: AUTO
+        uuid:
+            type: string
+            length: 36 
+            nullable: true
+            unique: true
         name:
             type: string
             length: 255

--- a/src/AppBundle/Resources/config/doctrine/Decklist.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Decklist.orm.yml
@@ -142,6 +142,11 @@ AppBundle\Entity\Decklist:
             generator:
                 strategy: AUTO
     fields:
+        uuid:
+            type: string
+            length: 36 
+            nullable: true
+            unique: true
         dateUpdate:
             type: datetime
             nullable: false

--- a/src/AppBundle/Resources/config/routing.yml
+++ b/src/AppBundle/Resources/config/routing.yml
@@ -48,11 +48,21 @@ deck_view:
     path: /{_locale}/deck/view/{deck_id}
     methods: [GET]
     defaults:
-        _controller: AppBundle:Builder:view
+        _controller: AppBundle:Builder:viewById
         _locale: en
     requirements:
         _locale: \w\w
         deck_id: \d+
+
+deck_view_by_uuid:
+    path: /{_locale}/deck/view/{uuid}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:Builder:viewByUuid
+        _locale: en
+    requirements:
+        _locale: \w\w
+        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 deck_duplicate:
     path: /{_locale}/deck/duplicate/{deck_id}
@@ -624,9 +634,17 @@ api_public_decklist:
     path: /api/2.0/public/decklist/{decklist_id}
     methods: [GET]
     defaults:
-        _controller: AppBundle:PublicApi20:decklist
+        _controller: AppBundle:PublicApi20:decklistById
     requirements:
         decklist_id: "\\d+"
+
+api_public_decklist_by_uuid:
+    path: /api/2.0/public/decklist/{uuid}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:PublicApi20:decklistByUuid
+    requirements:
+        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 api_public_decklists_by_date:
     path: /api/2.0/public/decklists/by_date/{date}
@@ -640,9 +658,17 @@ api_public_deck:
     path: /api/2.0/public/deck/{deck_id}
     methods: [GET]
     defaults:
-        _controller: AppBundle:PublicApi20:deck
+        _controller: AppBundle:PublicApi20:deckById
     requirements:
         deck_id: "\\d+"
+
+api_public_deck_by_uuid:
+    path: /api/2.0/public/deck/{uuid}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:PublicApi20:deckByUuid
+    requirements:
+        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 api_public_prebuilts:
     path: /api/2.0/public/prebuilts
@@ -662,13 +688,21 @@ api_private_decks:
     defaults:
         _controller: AppBundle:PrivateApi20:decks
 
-api_private_deck_load:
+api_private_deck_load_by_id:
     path: /api/2.0/private/deck/{deck_id}
     methods: [GET]
     defaults:
-        _controller: AppBundle:PrivateApi20:loadDeck
+        _controller: AppBundle:PrivateApi20:loadDeckById
     requirements:
         deck_id: "\\d+"
+
+api_private_deck_load_by_uuid:
+    path: /api/2.0/private/deck/{uuid}
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:PrivateApi20:loadDeckByUuid
+    requirements:
+        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
 api_private_deck_save:
     path: /api/2.0/private/deck/save

--- a/src/AppBundle/Service/DeckManager.php
+++ b/src/AppBundle/Service/DeckManager.php
@@ -5,14 +5,16 @@ namespace AppBundle\Service;
 
 use AppBundle\Entity\Card;
 use AppBundle\Entity\Deck;
+use AppBundle\Entity\Deckchange;
 use AppBundle\Entity\Decklist;
 use AppBundle\Entity\Deckslot;
 use AppBundle\Entity\Mwl;
 use AppBundle\Entity\Pack;
 use AppBundle\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Psr\Log\LoggerInterface;
-use AppBundle\Entity\Deckchange;
+use Ramsey\Uuid\Uuid;
 
 class DeckManager
 {
@@ -284,6 +286,12 @@ class DeckManager
             $deck->setMwl(null);
         }
 
+        // Note: We are doing the naive thing and just assuming we won't collide.
+		// If there is a collision, there will be an error returned to the user.
+		// Sorry, users!  v2 will be nicer to you!
+        if ($deck->getUuid() == null) {
+          $deck->setUuid(Uuid::uuid4()->toString());
+        }
         $deck->setName($name);
         $deck->setDescription($description);
         $deck->setUser($user);

--- a/src/AppBundle/Service/DecklistManager.php
+++ b/src/AppBundle/Service/DecklistManager.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\Deck;
 use AppBundle\Entity\Decklist;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Request;
 
 class DecklistManager


### PR DESCRIPTION
This is the first step in switching away from auto-incrementing IDs for decks and decklist.

This will prevent sequential scraping and (successfully) guessing at deck and decklist IDs.

We'll need followups for durable permalinks from this version of NRDB to v2.