### PR TITLE
Make legality history collapsible in decklist menus

### DIFF
--- a/app/Resources/views/Decklist/decklist.html.twig
+++ b/app/Resources/views/Decklist/decklist.html.twig
@@ -118,20 +118,51 @@ NRDB.user.params.decklist_id = Decklist.id;
 
 <!-- Legality -->
 <table class="table table-condensed" id="table-mwl">
-<thead>
-<tr><th colspan="1"><span class="glyphicon glyphicon-bell"></span> Legality</th></tr>
-</thead>
-<tbody>
-{% for legality in legalities %}
-<tr>
-    <td>
-      {% if legality.is_legal %}<span class="glyphicon glyphicon-thumbs-up" style="color:green"></span>
-      {% else %}<span class="glyphicon glyphicon-thumbs-down" style="color:red"></span>{% endif %}
-      <a href="#" class="change_mwl" data-code="{{ legality.code }}">{{ legality.name }}</a>
-    </td>
-</tr>
-{% endfor %}
-</tbody>
+  <thead>
+    <tr><th colspan="1"><span class="glyphicon glyphicon-bell"></span> Legality</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>
+      {# This makes two assumptions:
+       # 1) That there will be at least 2 legalities (should hold true indefinitely)
+       # 2) That if the first list isn't active, the second list is (probably holds)
+       #}
+      {% set is_current = legalities[0].active %}
+      {% if legalities[0].is_legal %}
+        <span class="glyphicon glyphicon-thumbs-up" style="color:green"></span>
+      {% else %}
+        <span class="glyphicon glyphicon-thumbs-down" style="color:red"></span>
+      {% endif %}
+      <a href="#" class="change_mwl" data-code="{{ legalities[0].code }}">
+        {{ legalities[0].name }} {% if is_current %}(active){% else %}(latest){% endif %}
+      </a>
+    </td></tr>
+    {% if not is_current %}
+      <tr><td>
+        {% if legalities[1].is_legal %}
+          <span class="glyphicon glyphicon-thumbs-up" style="color:green"></span>
+        {% else %}
+          <span class="glyphicon glyphicon-thumbs-down" style="color:red"></span>
+        {% endif %}
+        <a href="#" class="change_mwl" data-code="{{ legalities[1].code }}">{{ legalities[1].name }} (active)</a>
+      </td></tr>
+    {% endif %}
+    <tr id="open-lists"><td>
+      <a href="#">Show more</a>
+    </td></tr>
+    {% for legality in legalities|slice(is_current ? 1 : 2) %}
+    <tr class="other-list" style="display: none;"><td>
+      <a href="#" class="change_mwl" data-code="{{ legality.code }}">
+        {% if legality.is_legal %}<span class="glyphicon glyphicon-thumbs-up" style="color:green"></span>
+        {% else %}<span class="glyphicon glyphicon-thumbs-down" style="color:red"></span>{% endif %}
+        {{ legality.name }}
+      </a>
+    </td></tr>
+    {% endfor %}
+    <tr id="close-lists" style="display: none;"><td>
+      <a href="#">Show less</a>
+    </td></tr>
+  </tbody>
 </table>
 
 <!-- Rotation -->

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -358,7 +358,8 @@ class SocialController extends Controller
             "SELECT
                m.code,
                m.name,
-               l.is_legal
+               l.is_legal,
+               m.active
              FROM legality l
                LEFT JOIN mwl m ON l.mwl_id=m.id
              WHERE l.decklist_id=?

--- a/web/js/decklist.js
+++ b/web/js/decklist.js
@@ -326,6 +326,18 @@ $(function () {
         }
     }, 'a');
 
+    $('#open-lists a').on("click", function(event) {
+      $('#open-lists').hide();
+      $('#close-lists, .other-list').show();
+      event.preventDefault();
+    });
+
+    $('#close-lists a').on("click", function(event) {
+      $('#open-lists').show();
+      $('#close-lists, .other-list').hide();
+      event.preventDefault();
+    });
+
 });
 
 function copy_decklist() {


### PR DESCRIPTION
Public [decklist pages](https://netrunnerdb.com/en/decklist/68657/lucky-lat-2nd-january-startup-tournament-#table-mwl) currently display the legality of their decklist over all banlists/MWLs/etc in NR history. This makes all but the most recent legality list hidden by default (or the two most recent if the most recent list isn't yet active).

Should resolve issue #562.

![image](https://user-images.githubusercontent.com/26557961/150330453-eb74a5aa-d83a-4aeb-a31d-21e500aa4cb8.png)

![image](https://user-images.githubusercontent.com/26557961/150330477-ca44ac10-fb88-4f05-94ea-0628092e707b.png)
