### PR TITLE
Consolidate SBL show more/less click target on decklist

### DIFF
--- a/app/Resources/views/Decklist/decklist.html.twig
+++ b/app/Resources/views/Decklist/decklist.html.twig
@@ -119,7 +119,11 @@ NRDB.user.params.decklist_id = Decklist.id;
 <!-- Legality -->
 <table class="table table-condensed" id="table-mwl">
   <thead>
-    <tr><th colspan="1"><span class="glyphicon glyphicon-bell"></span> Legality</th></tr>
+    <tr>
+      <th colspan="1">
+        <span class="glyphicon glyphicon-bell"></span> Legality
+        <span id="open-lists" style="padding-left: 20px"><a href="#">(show more)</a></span></th>
+    </tr>
   </thead>
   <tbody>
     <tr><td>
@@ -147,9 +151,6 @@ NRDB.user.params.decklist_id = Decklist.id;
         <a href="#" class="change_mwl" data-code="{{ legalities[1].code }}">{{ legalities[1].name }} (active)</a>
       </td></tr>
     {% endif %}
-    <tr id="open-lists"><td>
-      <a href="#">Show more</a>
-    </td></tr>
     {% for legality in legalities|slice(is_current ? 1 : 2) %}
     <tr class="other-list" style="display: none;"><td>
       <a href="#" class="change_mwl" data-code="{{ legality.code }}">
@@ -159,9 +160,6 @@ NRDB.user.params.decklist_id = Decklist.id;
       </a>
     </td></tr>
     {% endfor %}
-    <tr id="close-lists" style="display: none;"><td>
-      <a href="#">Show less</a>
-    </td></tr>
   </tbody>
 </table>
 

--- a/web/js/decklist.js
+++ b/web/js/decklist.js
@@ -327,17 +327,15 @@ $(function () {
     }, 'a');
 
     $('#open-lists a').on("click", function(event) {
-      $('#open-lists').hide();
-      $('#close-lists, .other-list').show();
+      if ($('#open-lists a').text() == '(show more)') {
+         $('#open-lists a').text('(show less)'); 
+         $('.other-list').show();
+      } else {
+         $('#open-lists a').text('(show more)'); 
+         $('.other-list').hide();
+      }
       event.preventDefault();
     });
-
-    $('#close-lists a').on("click", function(event) {
-      $('#open-lists').show();
-      $('#close-lists, .other-list').hide();
-      event.preventDefault();
-    });
-
 });
 
 function copy_decklist() {


### PR DESCRIPTION
Move the show more/show less to the Legality level and keep the click target in the same place.
![Screenshot 2022-01-23 11 55 36 PM](https://user-images.githubusercontent.com/396562/150729687-fa2d6f43-02fa-47bf-8150-37bade05af64.png)
![Screenshot 2022-01-23 11 55 44 PM](https://user-images.githubusercontent.com/396562/150729694-fe508915-b21f-486e-9ad3-12afa74c9bba.png)

