### PR TITLE
Decklist selection

### DIFF
--- a/app/Resources/views/Builder/decks.html.twig
+++ b/app/Resources/views/Builder/decks.html.twig
@@ -47,22 +47,6 @@ var Identity = null,
 
 <div class="row" style="margin-bottom:10px">
 <div class="col-md-12">
-  <div class="btn-group" id="btn-group-selection">
-    <button type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown">
-      <span class="glyphicon glyphicon-briefcase"></span> With Selection <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu" role="menu">
-        <li class="dropdown-header"><span class="glyphicon glyphicon-transfer"></span> Compare</li>
-        <li><a href="#" id="btn-compare">Compare two or more decks</a></li>
-        <li><a href="#" id="btn-compare-collection">Compare one deck vs the others</a></li>
-        <li class="dropdown-header"><span class="glyphicon glyphicon-tag"></span> Tags</li>
-        <li><a href="#" id="btn-tag-add">Add one or more tags</a></li>
-      <li><a href="#" id="btn-tag-remove-one">Remove one or more tags</a></li>
-      <li><a href="#" id="btn-tag-remove-all">Clear all tags</a></li>
-      <li class="dropdown-header"><span class="glyphicon glyphicon-trash"></span> Delete</li>
-      <li><a href="#" id="btn-delete-selected"><span style="color:red" class="glyphicon glyphicon-warning-sign"></span> Delete all decks selected</a></li>
-    </ul>
-  </div>
   <div class="btn-group" id="btn-group-sort">
     <button type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown">
       <span class="glyphicon glyphicon-sort"></span> Sort List <span class="caret"></span>
@@ -81,8 +65,31 @@ var Identity = null,
 
 <div class="row" style="margin-bottom:10px">
 <div class="col-md-12">
-    <a role="button" class="btn btn-default btn-sm" href="{{ path('decks_download_all') }}">Download all decks</a>
-    <button role="button" class="btn btn-default btn-sm" id="decks_upload_all">Upload all decks</button>
+  <button role="button" class="btn btn-default btn-sm" id="select_all">Select all</button>
+  <button role="button" class="btn btn-default btn-sm" id="deselect_all">Deselect all</button>
+  <div class="btn-group" id="btn-group-selection">
+    <button type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown">
+      <span class="glyphicon glyphicon-briefcase"></span> With Selection <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+      <li class="dropdown-header"><span class="glyphicon glyphicon-transfer"></span> Compare</li>
+      <li><a href="#" id="btn-compare">Compare two or more decks</a></li>
+      <li><a href="#" id="btn-compare-collection">Compare one deck vs the others</a></li>
+      <li class="dropdown-header"><span class="glyphicon glyphicon-tag"></span> Tags</li>
+      <li><a href="#" id="btn-tag-add">Add one or more tags</a></li>
+      <li><a href="#" id="btn-tag-remove-one">Remove one or more tags</a></li>
+      <li><a href="#" id="btn-tag-remove-all">Clear all tags</a></li>
+      <li class="dropdown-header"><span class="glyphicon glyphicon-trash"></span> Delete</li>
+      <li><a href="#" id="btn-delete-selected"><span style="color:red" class="glyphicon glyphicon-warning-sign"></span> Delete all decks selected</a></li>
+    </ul>
+  </div>
+</div>
+</div>
+
+<div class="row" style="margin-bottom:10px">
+<div class="col-md-12">
+<a role="button" class="btn btn-default btn-sm" href="{{ path('decks_download_all') }}">Download all decks</a>
+<button role="button" class="btn btn-default btn-sm" id="decks_upload_all">Upload all decks</button>
 </div>
 </div>
 
@@ -90,36 +97,32 @@ var Identity = null,
 <div class="col-md-12" id="tag_toggles" title="Click to switch to this tag. Shift-click to toggle this tag.">
 </div>
 </div>
-
+<p><small><kbd>Enter</kbd> to open the last selected deck. <kbd>Esc</kbd> to close it.</small></p>
 </div>
 <!-- / Right-side column -->
 
 <!-- Left-side column -->
 <div class="col-md-7 col-md-pull-5">
-
 <h1>My private decks <small style="font-size:16px"{% if cannotcreate %} class="text-danger"{% endif %}>({{ nbdecks }}/{{ nbmax }} slots)</small></h1>
-
 <div class="row">
 <div class="col-md-12">
 <div class="list-group" id="decks" data-sort-type="date_update" data-sort-order="1">
 {% for deck in decks %}
 <a href="#" class="list-group-item deck-list-group-item" id="deck_{{ deck.id }}" data-id="{{ deck.id }}" data-problem="{{ deck.problem }}" data-faction="{{ deck.faction_code }}">
-    <div class="deck-list-identity-image hidden-xs" title="{{ deck.identity_title }}" style="background-image:url({{ asset('/card_image/small/'~deck.identity_code~'.jpg') }})"></div>
-    <h4 class="decklist-name">{{ deck.name }}{% if deck.message %} <span class="glyphicon glyphicon-exclamation-sign text-danger" title="{{ deck.message }}"></span>{% endif %}</h4>
-    <div>
-        {% if deck.identity_title %}{{ deck.identity_title }}{% else %}No Identity{% endif %}
-    </div><div class="deck-list-tags">
-        {% for tag in deck.tags %}<span class="label label-default tag-{{ tag }}">{{ tag }}</span>{% endfor %}
-    </div>
+  <div class="deck-list-identity-image hidden-xs" title="{{ deck.identity_title }}" style="background-image:url({{ asset('/card_image/small/'~deck.identity_code~'.jpg') }})"></div>
+  <h4 class="decklist-name">
+    <input type="checkbox" name="deck_select" value="{{ deck.id }}" style="margin-top: 0; transform: translateY(-1px)">
+    {{ deck.name }}{% if deck.message %} <span class="glyphicon glyphicon-exclamation-sign text-danger" title="{{ deck.message }}"></span>{% endif %}
+  </h4>
+  <div>{% if deck.identity_title %}{{ deck.identity_title }}{% else %}No Identity{% endif %}</div>
+  <div class="deck-list-tags" style="display:flex; flex-wrap:wrap;">
+    {% for tag in deck.tags %}<span class="label label-default tag-{{ tag }}">{{ tag }}</span>{% endfor %}
+  </div>
 </a>
 {% endfor %}
 </div>
-
-<p><small><kbd>Shift</kbd> to select multiple decks. <kbd>Enter</kbd> to open the last selected deck. <kbd>Esc</kbd> to close it.</small></p>
-
 </div>
 </div>
-
 </div>
 <!-- / Left-side column -->
 

--- a/app/Resources/views/Builder/decks.html.twig
+++ b/app/Resources/views/Builder/decks.html.twig
@@ -111,7 +111,7 @@ var Identity = null,
 <a href="#" class="list-group-item deck-list-group-item" id="deck_{{ deck.uuid }}" data-id="{{ deck.id }}" data-uuid="{{ deck.uuid }}" data-problem="{{ deck.problem }}" data-faction="{{ deck.faction_code }}">
   <div class="deck-list-identity-image hidden-xs" title="{{ deck.identity_title }}" style="background-image:url({{ asset('/card_image/small/'~deck.identity_code~'.jpg') }})"></div>
   <h4 class="decklist-name">
-    <input type="checkbox" name="deck_select" value="{{ deck.id }}" style="margin-top: 0; transform: translateY(-1px)">
+    <input type="checkbox" name="deck_select" value="{{ deck.uuid }}" style="margin-top: 0; transform: translateY(-1px)">
     {{ deck.name }}{% if deck.message %} <span class="glyphicon glyphicon-exclamation-sign text-danger" title="{{ deck.message }}"></span>{% endif %}
   </h4>
   <div>

--- a/app/Resources/views/Builder/decks.html.twig
+++ b/app/Resources/views/Builder/decks.html.twig
@@ -47,19 +47,8 @@ var Identity = null,
 
 <div class="row" style="margin-bottom:10px">
 <div class="col-md-12">
-  <div class="btn-group" id="btn-group-sort">
-    <button type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown">
-      <span class="glyphicon glyphicon-sort"></span> Sort List <span class="caret"></span>
-    </button>
-    <ul class="dropdown-menu" role="menu">
-      <li><a href="#" id="btn-sort-update">By date of last update</a></li>
-      <li><a href="#" id="btn-sort-creation">By date of creation</a></li>
-      <li><a href="#" id="btn-sort-faction">By faction</a></li>
-      <li><a href="#" id="btn-sort-identity">By identity</a></li>
-      <li><a href="#" id="btn-sort-lastpack">By last datapack</a></li>
-      <li><a href="#" id="btn-sort-name">By deck name</a></li>
-    </ul>
-  </div>
+<a role="button" class="btn btn-default btn-sm" href="{{ path('decks_download_all') }}">Download all decks</a>
+<button role="button" class="btn btn-default btn-sm" id="decks_upload_all">Upload all decks</button>
 </div>
 </div>
 
@@ -88,8 +77,19 @@ var Identity = null,
 
 <div class="row" style="margin-bottom:10px">
 <div class="col-md-12">
-<a role="button" class="btn btn-default btn-sm" href="{{ path('decks_download_all') }}">Download all decks</a>
-<button role="button" class="btn btn-default btn-sm" id="decks_upload_all">Upload all decks</button>
+  <div class="btn-group" id="btn-group-sort">
+    <button type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown">
+      <span class="glyphicon glyphicon-sort"></span> Sort List <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" role="menu">
+      <li><a href="#" id="btn-sort-update">By date of last update</a></li>
+      <li><a href="#" id="btn-sort-creation">By date of creation</a></li>
+      <li><a href="#" id="btn-sort-faction">By faction</a></li>
+      <li><a href="#" id="btn-sort-identity">By identity</a></li>
+      <li><a href="#" id="btn-sort-lastpack">By last datapack</a></li>
+      <li><a href="#" id="btn-sort-name">By deck name</a></li>
+    </ul>
+  </div>
 </div>
 </div>
 

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -1156,6 +1156,7 @@ class BuilderController extends Controller
                 'description' => $description,
                 'deck_id'     => $deck->getParent() ? $deck->getParent()->getId() : null,
                 'mwl_code'    => $mwl,
+                'tags'        => $deck->getTags(),
             ]
         );
     }

--- a/web/js/decks.js
+++ b/web/js/decks.js
@@ -3,6 +3,8 @@ $(document).on('data.app', function() {
   $('#btn-group-selection').on('click', 'button[id],a[id]', do_action_selection);
   $('#btn-group-sort').on('click', 'button[id],a[id]', do_action_sort);
   $('#decks_upload_all').on('click', decks_upload_all);
+  $('#select_all').on('click', select_all_visible);
+  $('#deselect_all').on('click', deselect_all);
 
   $('#menu-sort').on({
     change: function(event) {
@@ -24,36 +26,69 @@ $(document).on('data.app', function() {
   });
   update_tag_toggles();
 
-  $('body').on('click', 'a.deck-list-group-item', function (event) {
+  // Selects a decklist with its checkbox
+  $('a.deck-list-group-item :checkbox').change(function(event) {
+    if(this.checked)
+      select_deck($(`#deck_${$(this).val()}`));
+    else
+      deselect_deck($(`#deck_${$(this).val()}`));
+  });
+  // Ensures the checkbox isn't blocked by the decklist-expanding event
+  $('a.deck-list-group-item :checkbox').on('click', function(event) {
+    event.stopPropagation();
+  });
+
+  // Expands a decklist by clicking anywhere else on it
+  $('a.deck-list-group-item').on('click', function(event) {
     LastClickedDeck = this;
-    if(!event.shiftKey) {
-      $('#decks a.deck-list-group-item.selected').removeClass('selected');
-      $(this).addClass('selected');
-    } else {
-      $(this).toggleClass('selected');
-    }
-    if($(this).hasClass('selected')) {
-      if(!event.shiftKey) {
-        show_deck();
-      }
-    } else {
-      hide_deck();
-    }
-    return false;
+    show_deck();
   });
-  $('#decks').on('click', '#close_deck', function (event) {
+  // Close a deck by clicking on its exit button while its expanded
+  $('a.deck-list-group-item').on('click', '#close_deck', function (event) {
     hide_deck();
+    event.stopPropagation();
   });
+  // Expand/close a decklist with the keyboard
   $('.decks').keydown(function (event) {
-    if(event.which == 27) {
+    if(event.which == 27) { // Escape
       hide_deck();
-      }
-    if(event.which == 13) {
+    }
+    if(event.which == 13) { // Enter
       show_deck();
-      }
+    }
     return false;
+  });
+
+  // On load, reset all decklists with checked checkboxes as selected
+  $('a.deck-list-group-item :checkbox').each(function(i, e) {
+    if($(this).is(':checked'))
+      select_deck($(`#deck_${$(this).val()}`));
   });
 });
+
+function select_deck(obj) {
+  obj.addClass('selected');
+  obj.find(':checkbox').prop('checked', true);
+}
+
+function deselect_deck(obj) {
+  obj.removeClass('selected');
+  obj.find(':checkbox').prop('checked', false);
+}
+
+function select_all_visible() {
+  $('a.deck-list-group-item').each(function (i, e) {
+    if($(this).is(":visible")) {
+      select_deck($(this));
+    }
+  });
+}
+
+function deselect_all() {
+  $('a.deck-list-group-item').each(function (i, e) {
+    deselect_deck($(this));
+  });
+}
 
 function decks_upload_all() {
   $('#archiveModal').modal('show');
@@ -204,7 +239,7 @@ function filter_decks() {
   });
   list_id = list_id.filter(function (itm,i,a) { return i==a.indexOf(itm); });
   $('#decks a.deck-list-group-item').each(function (index, elt) {
-    $(elt).removeClass('selected');
+    deselect_deck($(elt));
     var id = $(elt).attr('id').replace('deck_', '');
     if(list_id.length && list_id.indexOf(id) === -1) $(elt).hide();
     else $(elt).show();

--- a/web/js/decks.js
+++ b/web/js/decks.js
@@ -28,10 +28,13 @@ $(document).on('data.app', function() {
 
   // Selects a decklist with its checkbox
   $('a.deck-list-group-item :checkbox').change(function(event) {
-    if(this.checked)
-      select_deck($(`#deck_${$(this).val()}`));
-    else
-      deselect_deck($(`#deck_${$(this).val()}`));
+    let deck = $(`#deck_${$(this).val()}`);
+    if(this.checked) {
+      LastClickedDeck = deck;
+      select_deck(deck);
+    } else {
+      deselect_deck(deck);
+    }
   });
   // Ensures the checkbox isn't blocked by the decklist-expanding event
   $('a.deck-list-group-item :checkbox').on('click', function(event) {

--- a/web/js/decks.v2.js
+++ b/web/js/decks.v2.js
@@ -274,7 +274,6 @@ function do_action_deck(event) {
 }
 
 function do_action_selection(event) {
-  event.stopPropagation();
   var action_id = $(this).attr('id');
   var uuids = [];
   $('#decks a.deck-list-group-item.selected').each(function (index, elt) { uuids.push($(elt).data('uuid')); });
@@ -287,7 +286,7 @@ function do_action_selection(event) {
     case 'btn-tag-remove-all': tag_clear(uuids); break;
     case 'btn-delete-selected': confirm_delete_all(uuids); break;
   }
-  return false;
+  return;
 }
 
 function do_action_sort(event) {


### PR DESCRIPTION
- Adds a checkbox to decks in the private deck selection page
  - Makes the functionality clearer 
  - Allows decks to be selected on mobile
- Removed the ability to select decks by shift clicking
- Updated the help text and moved it to the top of the page
- Added select/deselect all buttons
- Fixed deck duplication not copying the tags of the original decklist

Should resolve #565 and resolve #572.

![image](https://user-images.githubusercontent.com/26557961/150801144-951a4fa0-3394-46ee-8388-8aa5fb7e94dc.png)

![image](https://user-images.githubusercontent.com/26557961/150801198-b3989abd-98fb-410f-ba7d-0c8a3a090122.png)
