### PR TITLE
Add a link for legacy decklist url

### DIFF
--- a/app/Resources/views/Decklist/decklist.html.twig
+++ b/app/Resources/views/Decklist/decklist.html.twig
@@ -47,6 +47,15 @@ NRDB.user.params.decklist_id = Decklist.id;
                 <a id="social-icon-comment" href="#comments" class="social-icon-comment" data-toggle="tooltip" data-placement="bottom" title="Comment">
                   <span class="glyphicon glyphicon-comment"></span> <span class="num">{{ decklist.nbcomments }}</span>
                 </a>
+                |
+                <input type="hidden" id="legacy_decklist_url" value="{{ app.request.getSchemeAndHttpHost() }}{{ path('legacy_decklist', { decklist_id: decklist.id }) }}" />
+                <a href=""
+                   onClick="navigator.clipboard.writeText($('#legacy_decklist_url').val()).then(function() {
+                       alert('Copied ' + $('#legacy_decklist_url').val());
+                   }, function() {
+                       alert('Copy to clipboard failed. Sorry!');
+                   });
+                   return false;">Copy Legacy URL for Jinteki.net</a>
             </div>
             {% if duplicate %}
             | <small>Duplicate of <a href="{{ path('decklist_view', { 'decklist_uuid': duplicate.uuid, 'decklist_name': duplicate.prettyname|e('url') }) }}">{{ duplicate.name }}</a></small>


### PR DESCRIPTION
This will stick around until jnet is updated to support the new UUID-based decklist URLs.

![Screenshot 2022-02-08 11 17 17 PM](https://user-images.githubusercontent.com/396562/153126596-2b7667db-9630-4e21-b677-88753397d398.png)

