### PR TITLE
Search Improvements

### DIFF
--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -52,13 +52,14 @@
         </li>
         <li><b>Faction</b> <code>f</code> accepts full faction codes (e.g. nbn, haas-bioroid, weyland-consortium, sunny-lebeau, etc) or the following shortcuts:
           <ul>
-            <li>The first letter of each non-neutral faction (or the second letter for mini-factions)</li>
+            <li>The first letter of each non-neutral, non-mini factions</li>
+            <li>The second letter, or first two letters, of mini-factions (e.g. <code>p</code> or <code>ap</code> for Apex)
+            <li><code>mini</code> for all mini-factions</li>
             <li><code>nc</code> for <code>neutral-corp</code></li>
             <li><code>nr</code> for <code>neutral-runner</code></li>
             <li><code>-</code> or <code>neutral</code> for both neutral factions</li>
             <li><code>weyland</code> for <code>weyland-consortium</code></li>
             <li><code>hb</code> for <code>haas-bioroid</code></li>
-            <li><code>mini</code> for all mini-factions</li>
           </ul>
         </li>
         <li><b>Release Date</b> <code>r</code> is a special case using only the operators <code>&lt;</code> (inclusive) and <code>&gt;</code> (exclusive) and only understands the arguments <code>now</code> or a date YYYY-MM-DD</li>

--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -50,8 +50,19 @@
             <li><code>&gt;</code> &ndash; more than</li>
           </ul>
         </li>
-        <li><b>Special case</b> <code>r</code> (release date) uses only the operators <code>&lt;</code> (inclusive) and <code>&gt;</code> (exclusive) and only understands the arguments <code>now</code> or a date YYYY-MM-DD</li>
-        <li><b>Ban List</b> <code>b</code> will exclude any cards banned by that ban list. Ban List has 2 different special options in addition to specific Ban Lists: <code>active</code> or <code>latest</code>. These two only differ when there is a yet-to-be-active Ban List. Ban List can also specify a specific Ban List.  Valid Ban List options are 
+        <li><b>Faction</b> <code>f</code> accepts full faction codes (e.g. nbn, haas-bioroid, weyland-consortium, sunny-lebeau, etc) or the following shortcuts:
+          <ul>
+            <li>The first letter of each non-neutral faction (or the second letter for mini-factions)</li>
+            <li><code>nc</code> for <code>neutral-corp</code></li>
+            <li><code>nr</code> for <code>neutral-runner</code></li>
+            <li><code>neutral</code> for both neutral factions</li>
+            <li><code>weyland</code> for <code>weyland-consortium</code></li>
+            <li><code>hb</code> for <code>haas-bioroid</code></li>
+            <li><code>mini</code> for all mini-factions</li>
+          </ul>
+        </li>
+        <li><b>Release Date</b> <code>r</code> is a special case using only the operators <code>&lt;</code> (inclusive) and <code>&gt;</code> (exclusive) and only understands the arguments <code>now</code> or a date YYYY-MM-DD</li>
+        <li><b>Ban List</b> <code>b</code> will exclude any cards banned by that ban list. Ban List has 2 different special options in addition to specific Ban Lists: <code>active</code> or <code>latest</code>. These two only differ when there is a yet-to-be-active Ban List. Ban List can also specify a specific Ban List. Valid Ban List options are:
           <ul>
           {% set latest_found = false %}
           {% for banlist in banlists %}
@@ -59,7 +70,7 @@
           {% endfor %}
           </ul>
         </li>
-        <li><b>Rotation</b> <code>z</code> will restrict results to cards legal for that rotation. Rotation has 2 different special options in addition to specific rotations: <code>current</code> or <code>latest</code>. These two only differ when there is a yet-to-be-active rotation. Rotation can also specify a specific rotation.  Valid specific rotation options are 
+        <li><b>Rotation</b> <code>z</code> will restrict results to cards legal for that rotation. Rotation has 2 different special options in addition to specific rotations: <code>current</code> or <code>latest</code>. These two only differ when there is a yet-to-be-active rotation. Rotation can also specify a specific rotation. Valid specific rotation options are:
           <ul>
           {% set active_found = false %}
           {% set latest_found = false %}

--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -93,7 +93,7 @@
     <li><code>t:ice s!barrier|sentry|"code gate"</code> searches for all ICE that are neither barrier, code gate nor sentry</li>
     <li><code>r&lt;2013-01-01</code> searches for all cards released up to Jan 1, 2013</li>
     <li><code>d:r|c</code> searches for all Runner and Corp cards</li>
-    <li><code>x:&#34;the Corp loses 1[credit]&#34;</code> returns Amina, Corporate &#34;Grant&#34;, and Lamprey</li>
+    <li><code>x:&#34;the Corp loses 1 credit&#34;</code> returns Amina, Corporate &#34;Grant&#34;, and Lamprey</li>
     <li><code>d:corp z:current</code> returns all corp cards in the cycles valid for the latest rotation</li>
   </ul>
 </div>

--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -55,7 +55,7 @@
             <li>The first letter of each non-neutral faction (or the second letter for mini-factions)</li>
             <li><code>nc</code> for <code>neutral-corp</code></li>
             <li><code>nr</code> for <code>neutral-runner</code></li>
-            <li><code>neutral</code> for both neutral factions</li>
+            <li><code>-</code> or <code>neutral</code> for both neutral factions</li>
             <li><code>weyland</code> for <code>weyland-consortium</code></li>
             <li><code>hb</code> for <code>haas-bioroid</code></li>
             <li><code>mini</code> for all mini-factions</li>

--- a/app/Resources/views/Search/display.html.twig
+++ b/app/Resources/views/Search/display.html.twig
@@ -18,7 +18,7 @@
 {% else %}
 
 <div class="col-sm-12" style="margin-top:10px">
-  <p class="alert alert-warning">Your query didn't match any card.</p>
+  <p class="alert alert-warning">Your query didn't match any card. See the <a href="{{ path('search_syntax') }}">search syntax reference</a> for help.</p>
 </div>
 
 {% endif %}

--- a/app/Resources/views/Search/searchtooltip.html.twig
+++ b/app/Resources/views/Search/searchtooltip.html.twig
@@ -28,4 +28,4 @@ Filter operators:
 Examples:
    [ t:asset f:j|hb o&gt;2 ] - Jinteki or Haas-Bioroid assets with rez cost greater than 2
    [ t:program s!icebreaker n&lt;2 ] - non-icebreaker programs with 0 or 1 influence
-   [ x:&#34;the Corp loses 1[credit]&#34; ] - Amina, Corporate &#34;Grant&#34;, and Lamprey
+   [ x:&#34;the Corp loses 1 credit&#34; ] - Amina, Corporate &#34;Grant&#34;, and Lamprey

--- a/app/Resources/views/Search/searchtooltip.html.twig
+++ b/app/Resources/views/Search/searchtooltip.html.twig
@@ -3,7 +3,7 @@ Search filters:
    x - text (word or &#34;phrase with spaces and [symbols]&#34;)
    t - type (word)
    s - subtype (word or &#34;multiple - subtypes&#34;)
-   f - faction (letter or '-' for neutral)
+   f - faction (faction code, letter, or '-' for neutral)
    p - strength (number)
    m - memory (number)
    o - cost (number)

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -19,19 +19,27 @@ use Symfony\Component\Routing\RouterInterface;
 
 class CardsData
 {
-    public static $faction_letters = [
-        'haas-bioroid'       => 'h',
-        'weyland-consortium' => 'w',
-        'anarch'             => 'a',
-        'shaper'             => 's',
-        'criminal'           => 'c',
-        'jinteki'            => 'j',
-        'nbn'                => 'n',
-        'neutral-corp'       => '-',
-        'neutral-runner'     => '-',
-        'apex'               => 'p',
-        'adam'               => 'd',
-        'sunny-lebeau'       => 'u',
+    public static $faction_shortcuts = [
+        'neutral' => ['neutral-runner', 'neutral-corp'],
+        '-'       => ['neutral-runner', 'neutral-corp'],
+        'nc'      => 'neutral-corp',
+        'nr'      => 'neutral-runner',
+
+        'h'       => 'haas-bioroid',
+        'hb'      => 'haas-bioroid',
+        'j'       => 'jinteki',
+        'n'       => 'nbn',
+        'w'       => 'weyland-consortium',
+        'weyland' => 'weyland-consortium',
+
+        'a'       => 'anarch',
+        'c'       => 'criminal',
+        's'       => 'shaper',
+
+        'mini'    => ['apex', 'adam', 'sunny-lebeau'],
+        'p'       => 'apex',
+        'd'       => 'adam',
+        'u'       => 'sunny-lebeau',
     ];
 
     /** @var EntityManagerInterface $entityManager */
@@ -889,25 +897,13 @@ class CardsData
             }
             if ($l[0] == 'f') {
                 $factions = [];
-                for ($j = 1; $j < count($l); ++$j) {
-                    if (strlen($l[$j]) === 1) {
-                        // replace faction letter with full name
-                        $keys = array_keys(self::$faction_letters, $l[$j]);
-                        if (count($keys)) {
-                            array_push($factions, $keys[0]);
+                for ($j = 2; $j < count($l); ++$j) {
+                    if (array_key_exists($l[$j], self::$faction_shortcuts)) {
+                        if (is_array(self::$faction_shortcuts[$l[$j]])) {
+                            array_push($factions, ...self::$faction_shortcuts[$l[$j]]);
+                        } else {
+                            array_push($factions, self::$faction_shortcuts[$l[$j]]);
                         }
-                    } else if ($l[$j] == "neutral") {
-                        array_push($factions, "neutral-corp", "neutral-runner");
-                    } else if ($l[$j] == "weyland") {
-                        array_push($factions, "weyland-consortium");
-                    } else if ($l[$j] == "hb") {
-                        array_push($factions, "haas-bioroid");
-                    } else if ($l[$j] == "mini") {
-                        array_push($factions, "apex", "adam", "sunny-lebeau");
-                    } else if ($l[$j] == "nr") {
-                        array_push($factions, "neutral-runner");
-                    } else if ($l[$j] == "nc") {
-                        array_push($factions, "neutral-corp");
                     } else {
                         array_push($factions, $l[$j]);
                     }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -38,8 +38,11 @@ class CardsData
 
         'mini'    => ['apex', 'adam', 'sunny-lebeau'],
         'p'       => 'apex',
+        'ap'       => 'apex',
         'd'       => 'adam',
+        'ad'       => 'adam',
         'u'       => 'sunny-lebeau',
+        'su'       => 'sunny-lebeau',
     ];
 
     /** @var EntityManagerInterface $entityManager */

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -657,7 +657,7 @@ class CardsData
                             array_push($placeholders, "?$i");
                             $parameters[$i++] = $cycle;
                         }
-                        $clauses[] = "(y.code not in (" . implode(", ", $placeholders) . "))";
+                        $clauses[] = "(y.code not in (" . implode(", ", $placeholders) . ") and y.code != 'draft')";
                     }
                     $i++;
                     break;

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -622,7 +622,7 @@ class CardsData
                     }
                     $i++;
                     break;
-                case 'b': // ban list 
+                case 'b': // ban list
                     $mwl = null;
                     if ($condition[0] == "active") {
                         $mwl = $this->entityManager->getRepository(Mwl::class)->findOneBy(['active' => 1], ["dateStart" => "DESC"]);
@@ -896,6 +896,18 @@ class CardsData
                         if (count($keys)) {
                             array_push($factions, $keys[0]);
                         }
+                    } else if ($l[$j] == "neutral") {
+                        array_push($factions, "neutral-corp", "neutral-runner");
+                    } else if ($l[$j] == "weyland") {
+                        array_push($factions, "weyland-consortium");
+                    } else if ($l[$j] == "hb") {
+                        array_push($factions, "haas-bioroid");
+                    } else if ($l[$j] == "mini") {
+                        array_push($factions, "apex", "adam", "sunny-lebeau");
+                    } else if ($l[$j] == "nr") {
+                        array_push($factions, "neutral-runner");
+                    } else if ($l[$j] == "nc") {
+                        array_push($factions, "neutral-corp");
                     } else {
                         array_push($factions, $l[$j]);
                     }


### PR DESCRIPTION
- Resolves #552 - draft cards can no longer appear when a rotation is specified (this isn't a perfect solution but is unlikely to ever be a problem - the ideal fix would be to have draft and standard be explicit formats)
- Fixed `f:-` only finding neutral corp cards (now finds neutral runner cards as well)
- Added the following shortcuts: 
  - `nc` - Neutral corp cards
  - `nr` - Neutral runner cards
  - `neutral` - Alternative shortcut for all neutral cards
  - `ap`, `ad`, `su` - Alternative shortcuts for the mini-factions (resolves #553)
  - `mini` - All mini-factions
  - `hb` - HB
  - `weyland` - Weyland
- Updated and fixed the search syntax reference
- The search syntax reference is now linked when a search fails to find any cards