### PR TITLE
Process foreign keys before optional fields to fix dependency order.

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -569,10 +569,6 @@ class ImportStdCommand extends ContainerAwareCommand
             $this->copyKeyToEntity($entity, $entityName, $data, $key, true);
         }
 
-        foreach ($optionalKeys as $key) {
-            $this->copyKeyToEntity($entity, $entityName, $data, $key, false);
-        }
-
         foreach ($foreignKeys as $key) {
             $foreignEntityShortName = ucfirst(str_replace('_code', '', $key));
 
@@ -599,6 +595,10 @@ class ImportStdCommand extends ContainerAwareCommand
                 $setter = 'set' . $foreignEntityShortName;
                 $entity->$setter($foreignEntity);
             }
+        }
+
+        foreach ($optionalKeys as $key) {
+            $this->copyKeyToEntity($entity, $entityName, $data, $key, false);
         }
 
         // special case for Card


### PR DESCRIPTION
It looks like the special casing added in #507 introduced a dependency issue causing the check to fail because the type of the entity wasn't actually set yet.