### PR TITLE
Minor search fixes

### DIFF
--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -79,7 +79,7 @@
           {% endfor %}
           </ul>
         </li>
-        <li><b>Rotation</b> <code>z</code> will restrict results to cards legal for that rotation. Rotation has 2 different special options in addition to specific rotations: <code>current</code> or <code>latest</code>. These two only differ when there is a yet-to-be-active rotation. Rotation can also specify a specific rotation. Valid specific rotation options are:
+        <li><b>Rotation</b> <code>z</code> will restrict results to cards legal for that rotation. Rotation has 3 different special options in addition to specific rotations: <code>current</code>, <code>latest</code>, and <code>startup</code>. These two only differ when there is a yet-to-be-active rotation. Rotation can also specify a specific rotation. Valid specific rotation options are:
           <ul>
           {% set active_found = false %}
           {% set latest_found = false %}

--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -100,13 +100,13 @@
     <li><code>t:asset</code> searches for all Assets</li>
     <li><code>t:asset s:ambush</code> searches for every Asset that has the subtype Ambush</li>
     <li><code>x:"make a run"</code> searches for all cards with the text "make a run"</li>
-    <li><code>t:asset|upgrade f:n</code> searches for all Assets and Upgrades from NBN</li>
-    <li><code>f:a|s n&lt;3</code> searches for all Anarch and Shaper cards with a faction cost less than 3</li>
+    <li><code>t:asset|upgrade f:n</code> searches for all NBN cards that are Assets or Upgrades</li>
+    <li><code>f:a|s n&lt;3</code> searches for all Anarch or Shaper cards with a faction cost less than 3</li>
     <li><code>t:ice s!barrier|sentry|"code gate"</code> searches for all ICE that are neither barrier, code gate nor sentry</li>
     <li><code>r&lt;2013-01-01</code> searches for all cards released up to Jan 1, 2013</li>
-    <li><code>d:r|c</code> searches for all Runner and Corp cards</li>
+    <li><code>d:r|c</code> searches for all Runner or Corp cards</li>
     <li><code>x:&#34;the Corp loses 1 credit&#34;</code> returns Amina, Corporate &#34;Grant&#34;, and Lamprey</li>
-    <li><code>d:corp z:current</code> returns all corp cards in the cycles valid for the latest rotation</li>
+    <li><code>d:corp z:current</code> returns all Corp cards in the cycles valid for the latest rotation</li>
   </ul>
 
   <h2>Card aliases</h2>

--- a/app/Resources/views/Search/searchtooltip.html.twig
+++ b/app/Resources/views/Search/searchtooltip.html.twig
@@ -16,7 +16,7 @@ Search filters:
    u - unique (0 for non-unique, 1 for unique)
    y - quantity in pack (number)
    b - ban list (one of: active, latest, or an mwl name).
-   z - rotation (one of: current, latest, rotation-2017, rotation-2018, rotation-2019, rotation-2021)
+   z - rotation (one of: current, latest, startup, rotation-2017, rotation-2018, rotation-2019, rotation-2021)
 
 Filter operators:
    : - include or is equal to the condition

--- a/web/card_aliases.txt
+++ b/web/card_aliases.txt
@@ -11,7 +11,7 @@ eddy kim : Edward Kim: Humanity's Hammer
 etf : Haas-Bioroid: Engineering the Future
 gabe : Gabriel Santiago: Consummate Professional
 prede : Haas-Bioroid: Precision Design
-r+ : NBN: Reality Plus
+# r+ : NBN: Reality Plus
 seidr labs : Seidr Laboratories: Destiny Defined
 blorch : Black Orchestra
 clippy : Paperclip
@@ -98,7 +98,7 @@ yogurt : Economic Warfare
 cell phones : 02069
 cell phone man : 02069
 mister phones : 02069
-mr phones : 02069
+# mr phones : 02069
 
 # Cars
 nice car : Sports Hopper


### PR DESCRIPTION
- Removed some card aliases that interact weirdly with the search syntax
- Documented `z:startup` as a valid search query
- Clarifies some wording in the syntax guide (resolving #602)