### PR TITLE
More minor search fixes

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -425,14 +425,15 @@ class SearchController extends Controller
         $rows = $cardsData->get_search_rows($conditions, $sort, $locale);
 
         // If there are no results, and no specific criteria were searched, try again but force acronyms
-        if (!$rows && !array_filter($conditions, function($c) {return $c[0] != "_";})) {
-            $capsConditions = array_map(function($c) {return ["_", $c[1], strtoupper($c[2])];}, $conditions);
+        if (!$rows && $cardsData->simplifyConditions($conditions)) {
+            $capsConditions = [["_", ":", strtoupper($conditions[0][2])]];
             $rows = $cardsData->get_search_rows($capsConditions, $sort, $locale);
 
-            // If there are still no results, try again but with aliases
+            // If there are results, rebuild the query from the uppercase conditions
             if ($rows) {
                 $conditions = $capsConditions;
             }
+            // If there are still no results, try again but with aliases
             else {
                 $cardsData->unaliasCardNames($conditions);
                 $rows = $cardsData->get_search_rows($conditions, $sort, $locale);

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -434,8 +434,7 @@ class SearchController extends Controller
                 $conditions = $capsConditions;
             }
             // If there are still no results, try again but with aliases
-            else {
-                $cardsData->unaliasCardNames($conditions);
+            else if ($cardsData->unaliasCardNames($conditions)) {
                 $rows = $cardsData->get_search_rows($conditions, $sort, $locale);
             }
         }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -947,14 +947,31 @@ class CardsData
         }
     }
 
+    public function simplifyConditions(array &$conditions)
+    {
+        // Checks if the given conditions are valid
+        if (array_filter($conditions, function($c) {return $c[0] != "_" || $c[1] != ":";}))
+            return false;
+
+        // Combine all conditions into a single string
+        $s = preg_replace("/[^A-Za-z0-9 ]/", "", implode(" ", array_map(function($c) {return $c[2];}, $conditions)));
+
+        // Update the array if the combined conditions are non-empty
+        if (!$s)
+            return false;
+        $conditions = [["_", ":", strtolower($s)]];
+        return true;
+    }
+
+    // Assumes given conditions are simplified
     public function unaliasCardNames(array &$conditions)
     {
-        // Join all the conditions without criteria into a single string
-        $title = preg_replace("/[^A-Za-z0-9 ]/", "", implode(" ", array_map(function($c) {return $c[0] == "_" ? strtolower($c[2]) : "";}, $conditions)));
+        // Get the simplified conditions
+        $title = $conditions[0][2];
 
-        if (!$title) {
+        // Check the conditions are non-empty
+        if (!$title)
             return;
-        }
 
         // If they are the substring of an alias for a card, replace the conditions with that card's name
         if ($match = current(preg_grep("/^$title/", array_keys($this->cardAliases)))) {

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -971,12 +971,14 @@ class CardsData
 
         // Check the conditions are non-empty
         if (!$title)
-            return;
+            return false;
 
         // If they are the substring of an alias for a card, replace the conditions with that card's name
         if ($match = current(preg_grep("/^$title/", array_keys($this->cardAliases)))) {
             $conditions = [["_", ":", $this->cardAliases[$match]]];
+            return true;
         }
+        return false;
     }
 
     public function buildQueryFromConditions(array $conditions)

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -267,7 +267,7 @@ class CardsData
                             $parameters[$i++] = "%$arg%";
                         }
                     }
-                    $clauses[] = implode(" or ", $or);
+                    $clauses[] = implode($operator == '!' ? " and " : " or ", $or);
                     break;
                 case 'x': // text
                     $or = [];

--- a/web/card_aliases.txt
+++ b/web/card_aliases.txt
@@ -98,7 +98,7 @@ yogurt : Economic Warfare
 cell phones : 02069
 cell phone man : 02069
 mister phones : 02069
-# mr phones : 02069
+mr phones : 02069
 
 # Cars
 nice car : Sports Hopper


### PR DESCRIPTION
- Fixed negative conjunctions in title queries not working (e.g. `_!a|e|i|o|u`)
- Fixed some queries being matched as acronyms when they shouldn't be (e.g. `mr phones` matched cards with the acronym **MR**)