### PR TITLE
Added an update log to the home page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /web/card_image/
 /web/corp.json
 /web/runner.json
+/web/update_log.txt

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ To update the deck of the week on the front page:
 
 where `decklist_id` is the numeric id of the deck you want to highlight.
 
+## Update log
+
+If you want to show site updates on the home page, copy `web/update_log.example.txt` to `web/update_log.txt` and copy the format with your own data. The update log shows dates, each with a list of updates. The update log should be kept fairly concise, with only information that is relevant to users of the website, not developers.
+
 ## Setup an admin account
 
 - register

--- a/app/Resources/views/Default/index.html.twig
+++ b/app/Resources/views/Default/index.html.twig
@@ -29,6 +29,7 @@ var Identity = null,
 {% block body %}
 
 <div class="container" id="index_page">
+{% include '/Default/update-log.html.twig' %}
   {% include '/Default/navbar-factions.html.twig' %}
   <div class="row">
     <div class="col-md-8">

--- a/app/Resources/views/Default/update-log.html.twig
+++ b/app/Resources/views/Default/update-log.html.twig
@@ -1,23 +1,25 @@
-<div id="update-log" class="container-fluid hidden-xs">
-    <table>
-        <thead>
-            <tr>
-                <th colspan="2">Updates <a href="">(show more)</a></th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for update in updates %}
+{% if updates is not empty %}
+    <div id="update-log" class="container-fluid hidden-xs">
+        <table>
+            <thead>
                 <tr>
-                    <td class="date">{{ update.date }}</td>
-                    <td>
-                        <ul>
-                            {% for entry in update.entries %}
-                                <li>{{ entry }}</li>
-                            {% endfor %}
-                        </ul>
-                    </td>
+                    <th colspan="2">Updates <a href="">(show more)</a></th>
                 </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-</div>
+            </thead>
+            <tbody>
+                {% for update in updates %}
+                    <tr>
+                        <td class="date">{{ update.date }}</td>
+                        <td>
+                            <ul>
+                                {% for entry in update.entries %}
+                                    <li>{{ entry }}</li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endif %}

--- a/app/Resources/views/Default/update-log.html.twig
+++ b/app/Resources/views/Default/update-log.html.twig
@@ -1,0 +1,23 @@
+<div id="update-log" class="container-fluid hidden-xs">
+    <table>
+        <thead>
+            <tr>
+                <th colspan="2">Updates <a href="">(show more)</a></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for update in updates %}
+                <tr>
+                    <td class="date">{{ update.date }}</td>
+                    <td>
+                        <ul>
+                            {% for entry in update.entries %}
+                                <li>{{ entry }}</li>
+                            {% endfor %}
+                        </ul>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/src/AppBundle/Controller/IndexController.php
+++ b/src/AppBundle/Controller/IndexController.php
@@ -36,6 +36,28 @@ class IndexController extends Controller
         // recent decklists
         $decklists_recent = $decklistManager->recent(0, 10, false)['decklists'];
 
+        // load site updates
+        $file = fopen('update_log.txt', 'r');
+        $updates = [];
+        $update = null;
+        if ($file) {
+            while (($line = fgets($file)) !== false) {
+                $line = trim($line);
+                if (empty($line))
+                    continue;
+                if ($line[0] !== '-') {
+                    if ($update != null) {
+                        $updates[] = $update;
+                    }
+                    $update = array('date' => $line, 'entries' => []);
+                } else if ($update !== null) {
+                    $update['entries'][] = trim(substr($line, 1));
+                }
+            }
+            $updates[] = $update;
+        }
+        fclose($file);
+
         return $this->render(
 
             'Default/index.html.twig',
@@ -45,6 +67,7 @@ class IndexController extends Controller
                 'decklists'       => $decklists_recent,
                 'decklist'        => $decklist,
                 'url'             => $request->getRequestUri(),
+                'updates'         => $updates,
             ],
 
             $response

--- a/src/AppBundle/Controller/IndexController.php
+++ b/src/AppBundle/Controller/IndexController.php
@@ -37,26 +37,28 @@ class IndexController extends Controller
         $decklists_recent = $decklistManager->recent(0, 10, false)['decklists'];
 
         // load site updates
-        $file = fopen('update_log.txt', 'r');
         $updates = [];
-        $update = null;
-        if ($file) {
-            while (($line = fgets($file)) !== false) {
-                $line = trim($line);
-                if (empty($line))
-                    continue;
-                if ($line[0] !== '-') {
-                    if ($update != null) {
-                        $updates[] = $update;
+        if (file_exists('update_log.txt')) {
+            $file = fopen('update_log.txt', 'r');
+            $update = null;
+            if ($file) {
+                while (($line = fgets($file)) !== false) {
+                    $line = trim($line);
+                    if (empty($line))
+                        continue;
+                    if ($line[0] !== '-') {
+                        if ($update != null) {
+                            $updates[] = $update;
+                        }
+                        $update = array('date' => $line, 'entries' => []);
+                    } else if ($update !== null) {
+                        $update['entries'][] = trim(substr($line, 1));
                     }
-                    $update = array('date' => $line, 'entries' => []);
-                } else if ($update !== null) {
-                    $update['entries'][] = trim(substr($line, 1));
                 }
+                $updates[] = $update;
             }
-            $updates[] = $update;
+            fclose($file);
         }
-        fclose($file);
 
         return $this->render(
 

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -621,6 +621,51 @@ ul.rulings-list blockquote {
   width: 1px;
 }
 
+/* Update log */
+#update-log {
+  margin-bottom: 20px;
+  padding: 0;
+  border: 1px solid #eee;
+  border-radius: 5px;
+  background: #f8f8f8;
+}
+#update-log table {
+  width: 100%;
+}
+#update-log tbody {
+  display: block;
+  width: 100%;
+  padding-left: 20px;
+  max-height: 120px;
+  overflow-y: scroll;
+  transition: max-height 1s;
+}
+#update-log th {
+  padding-top: 7px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid #eee;
+  text-align: center;
+}
+#update-log tr {
+  color: #888;
+  border-bottom: 1px solid #eee;
+  vertical-align: top;
+}
+#update-log tr:first-child {
+  color: black;
+}
+#update-log td {
+  padding-top: 8px;
+}
+#update-log .date {
+  font-weight: bold;
+  text-align: right;
+  padding-right: 1em;
+}
+#update-log ul {
+  list-style-type: '-  ';
+}
+
 /******** fix for twitter typehead + bootstrap input-group-btn ***********/
 
 .input-group .twitter-typeahead {

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -48,4 +48,17 @@ $(function() {
     keyup : debounce(handle_input_change, 250)
   });
 
+  $('#update-log a').click(function (event) {
+    event.preventDefault();
+    let l = event.currentTarget;
+    if (l.text == '(show more)') {
+      l.text = '(show less)';
+      $('#update-log tbody').css("max-height", "400px");
+    } else {
+      l.text = '(show more)';
+      $('#update-log tbody').css("max-height", "");
+    }
+    return false;
+  });
+
 });

--- a/web/update_log.example.txt
+++ b/web/update_log.example.txt
@@ -1,5 +1,6 @@
 Saturday, 28 June, 8128
 - This update is in the future.
+- To show updates on the home page, copy this file as "update_log.txt" and fill it with appropriate data in this format.
 
 Saturday, 1 January, 2000
 - Turn of the Millennium

--- a/web/update_log.txt
+++ b/web/update_log.txt
@@ -1,0 +1,9 @@
+Saturday, 28 June, 8128
+- This update is in the future.
+
+Saturday, 1 January, 2000
+- Turn of the Millennium
+- An example of an update with multiple entries was added.
+
+Thursday, 1 January, 1970
+- Time began.


### PR DESCRIPTION
Adds a list of site updates to the home page:
![image](https://user-images.githubusercontent.com/26557961/165737380-951200b5-edd1-4070-aac3-5b6b2a574d5f.png)
![image](https://user-images.githubusercontent.com/26557961/165737897-f4ed0bb7-f2c1-4403-80f6-050e9ed8879f.png)
This mirrors the update log jinteki.net has on its homepage.

In this implementation updates have to be added manually to `web/update_log.txt`. A database table would be cleaner, but ultimately requires the same steps but with additional tedium. If `web/update_log.txt` doesn't exist, the update log isn't shown at all.