### PR TITLE
Bug fixes

### DIFF
--- a/app/Resources/views/Default/update-log.html.twig
+++ b/app/Resources/views/Default/update-log.html.twig
@@ -3,7 +3,7 @@
         <table>
             <thead>
                 <tr>
-                    <th colspan="2">Updates <a href="">(show more)</a></th>
+                    <th colspan="2">Updates <a href="">(expand)</a></th>
                 </tr>
             </thead>
             <tbody>

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -551,7 +551,7 @@ class SearchController extends Controller
                 }
                 if ($view == "rulings") {
                     $cardVersions = $versions[$card->getTitle()];
-                    $cardinfo['rulings'] = $cardsData->get_rulings(array($cardVersions));
+                    $cardinfo['rulings'] = $cardsData->get_rulings($cardVersions);
                 }
                 $cards[] = $cardinfo;
             }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -698,7 +698,7 @@ class CardsData
                                 $parameters[$i++] = $cycle;
                             }
                             if ($operator == ":") {
-                                $clauses[] = "(y.code not in (" . implode(", ", $placeholders) . ") and y.code != 'draft'";
+                                $clauses[] = "(y.code not in (" . implode(", ", $placeholders) . ") and y.code != 'draft')";
                             } else {
                                 $clauses[] = "(y.code in (" . implode(", ", $placeholders) . "))";
                             }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -668,6 +668,7 @@ class CardsData
                     $i++;
                     break;
                 case 'z': // rotation
+                    $condition[0] = strtolower($condition[0]);
                     if ($condition[0] == "startup") {
                         // Add the valid cycles for startup and add them to the WHERE clause for the query.
                         $cycles = ['ashes', 'system-gateway', 'system-update-2021', 'borealis'];

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -622,7 +622,10 @@ ul.rulings-list blockquote {
   white-space:nowrap;
 }
 .legality-interactive:before {
-  transition: min-width 0.5s, content 0.5s;
+  transition: min-width 0.5s;
+}
+.legality-interactive.legality-restricted:before {
+  transition: none; /* "RESTRICTED" is too long and makes the animation weird */
 }
 .legality-interactive:not(:hover):not(:active):before {
   content: "!";

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -51,11 +51,11 @@ $(function() {
   $('#update-log a').click(function (event) {
     event.preventDefault();
     let l = event.currentTarget;
-    if (l.text == '(show more)') {
-      l.text = '(show less)';
+    if (l.text == '(expand)') {
+      l.text = '(hide)';
       $('#update-log tbody').css("max-height", "400px");
     } else {
-      l.text = '(show more)';
+      l.text = '(expand)';
       $('#update-log tbody').css("max-height", "");
     }
     return false;

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -52,7 +52,7 @@ $(function() {
     event.preventDefault();
     let l = event.currentTarget;
     if (l.text == '(expand)') {
-      l.text = '(hide)';
+      l.text = '(shrink)';
       $('#update-log tbody').css("max-height", "400px");
     } else {
       l.text = '(expand)';


### PR DESCRIPTION
- `z` search query no longer raises a 500 error
- `z` search query is no longer case sensitive
- Made the expand button on the update log clearer ("show more" -> "expand"; "show less" -> "shrink")
- Fixed every ruling being "Cards trashed by Noise’s ability are placed facedown in Archives."
- Interactive ROTATED label (on decklists and in the deckbuilder) no longer animates.