### PR TITLE
Move update log to the bottom of the homepage, above the footer.

### DIFF
--- a/app/Resources/views/Default/index.html.twig
+++ b/app/Resources/views/Default/index.html.twig
@@ -29,7 +29,6 @@ var Identity = null,
 {% block body %}
 
 <div class="container" id="index_page">
-{% include '/Default/update-log.html.twig' %}
   {% include '/Default/navbar-factions.html.twig' %}
   <div class="row">
     <div class="col-md-8">
@@ -39,6 +38,8 @@ var Identity = null,
       {% include '/Default/recent_decklists.html.twig' %}
     </div>
   </div>
+  {% include '/Default/update-log.html.twig' %}
 </div> <!-- .container -->
+
 
 {% endblock %}

--- a/app/Resources/views/Default/update-log.html.twig
+++ b/app/Resources/views/Default/update-log.html.twig
@@ -4,7 +4,7 @@
             <thead>
                 <tr>
                     <th colspan="2">
-                      Updates <a href="">(expand)</a>
+                      NetrunnerDB Updates <a href="">(expand)</a>
                       <button type="button" class="close" id="close-updates"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
                     </th>
                 </tr>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -658,7 +658,7 @@ ul.rulings-list blockquote {
 
 /* Update log */
 #update-log {
-  margin-bottom: 20px;
+  margin-top: 40px;
   padding: 0;
   border: 1px solid #eee;
   border-radius: 5px;


### PR DESCRIPTION
I like the updates, but they won't be relevant enough to justify being at the top of the homepage, IMO.  Happy to do something else if we want.

<img width="1193" alt="Screen Shot 2022-05-14 at 12 27 41 PM" src="https://user-images.githubusercontent.com/396562/168442385-289cdacb-c4e7-4a8c-ae3d-ab178b05c848.png">

Mostly addresses #630 