### PR TITLE
Improvements to legality indicators

### DIFF
--- a/app/Resources/views/Rotation/rotation.html.twig
+++ b/app/Resources/views/Rotation/rotation.html.twig
@@ -104,16 +104,16 @@ var rotations = new Array();
 
       <div class="col-sm-6">
         <div>
-          <a id="all">All</a> | 
-          <a id="none">None</a> | 
-          <a id="only_corp">Only Corp</a> | 
+          <a id="all">All</a> |
+          <a id="none">None</a> |
+          <a id="only_corp">Only Corp</a> |
           <a id="only_corp_types">Corp Types</a> |
           <a id="only_runner">Only Runner</a> |
           <a id="only_runner_types">Runner Types</a>
         </div>
         <div id="faction_code" class="filter btn-group btn-group-justified" data-toggle="buttons"></div>
         <div id="type_code" class="filter btn-group btn-group-justified" data-toggle="buttons"></div>
-        <div><p>Changed Cards</p></div>
+        <div><h3>Changed Cards</h3></div>
         <div id="diffs"></div>
       </div>
     </div>

--- a/app/Resources/views/Search/display-set.html.twig
+++ b/app/Resources/views/Search/display-set.html.twig
@@ -11,9 +11,12 @@
                <th>Name</th>
                <th>Cards</th>
                <th>Release Date</th>
+               <th style="text-align: center">Standard</th>
+               <th style="text-align: center">Startup</th>
             </tr>
          </thead>
          {% for cycle in data %}
+         {% set standalone = cycle.packs is not defined %}
             <tr class="odd">
                <td data-th="Name">
                   <a href="{{ cycle.url }}" class="card" data-index="{{ cycle.code }}">
@@ -30,6 +33,24 @@
                </td>
                <td data-th="Date">
                   {{ cycle.available }}
+               </td>
+               <td style="text-align: center">
+                 {% if standalone %}
+                   {% if cycle.standard and cycle.code != "draft" %}
+                     <span class="legality-legal">
+                   {% else %}
+                     <span class="legality-unavailable">
+                   {% endif %}
+                 {% endif %}
+               </td>
+               <td style="text-align: center">
+                 {% if standalone %}
+                   {% if cycle.startup %}
+                     <span class="legality-legal">
+                   {% else %}
+                     <span class="legality-unavailable">
+                   {% endif %}
+                 {% endif %}
                </td>
             </tr>
             {% if cycle.packs is defined %}
@@ -50,6 +71,20 @@
                      </td>
                      <td data-th="Date">
                         {{ pack.available }}
+                     </td>
+                     <td style="text-align: center">
+                       {% if pack.standard %}
+                         <span class="legality-legal">
+                       {% else %}
+                         <span class="legality-unavailable">
+                       {% endif %}
+                     </td>
+                     <td style="text-align: center">
+                       {% if pack.startup %}
+                         <span class="legality-legal">
+                       {% else %}
+                         <span class="legality-unavailable">
+                       {% endif %}
                      </td>
                   </tr>
                {% endfor %}

--- a/app/Resources/views/Search/display-set.html.twig
+++ b/app/Resources/views/Search/display-set.html.twig
@@ -35,9 +35,9 @@
                <td data-th="Date">
                   {{ cycle.available }}
                </td>
-               <td style="text-align: center">{% if cycle.standard %}✓{% endif %}</td>
-               <td style="text-align: center">{% if cycle.startup %}✓{% endif %}</td>
-               <td style="text-align: center">{% if cycle.eternal %}✓{% endif %}</td>
+               <td class="desktop-centered" data-th="Standard">{% if cycle.standard %}✓{% endif %}</td>
+               <td class="desktop-centered" data-th="Startup">{% if cycle.startup %}✓{% endif %}</td>
+               <td class="desktop-centered" data-th="Eternal">{% if cycle.eternal %}✓{% endif %}</td>
             </tr>
             {% if cycle.packs is defined %}
                {% for pack in cycle.packs %}
@@ -58,9 +58,9 @@
                      <td data-th="Date">
                         {{ pack.available }}
                      </td>
-                     <td style="text-align: center">{% if pack.standard %}✓{% endif %}</td>
-                     <td style="text-align: center">{% if pack.startup %}✓{% endif %}</td>
-                     <td style="text-align: center">{% if cycle.eternal %}✓{% endif %}</td>
+                     <td class="desktop-centered" data-th="Standard">{% if pack.standard %}✓{% endif %}</td>
+                     <td class="desktop-centered" data-th="Startup">{% if pack.startup %}✓{% endif %}</td>
+                     <td class="desktop-centered" data-th="Eternal">{% if pack.eternal %}✓{% endif %}</td>
                   </tr>
                {% endfor %}
             {% endif %}

--- a/app/Resources/views/Search/display-set.html.twig
+++ b/app/Resources/views/Search/display-set.html.twig
@@ -13,6 +13,7 @@
                <th>Release Date</th>
                <th style="text-align: center">Standard</th>
                <th style="text-align: center">Startup</th>
+               <th style="text-align: center">Eternal</th>
             </tr>
          </thead>
          {% for cycle in data %}
@@ -34,24 +35,9 @@
                <td data-th="Date">
                   {{ cycle.available }}
                </td>
-               <td style="text-align: center">
-                 {% if standalone %}
-                   {% if cycle.standard and cycle.code != "draft" %}
-                     <span class="legality-legal">
-                   {% else %}
-                     <span class="legality-unavailable">
-                   {% endif %}
-                 {% endif %}
-               </td>
-               <td style="text-align: center">
-                 {% if standalone %}
-                   {% if cycle.startup %}
-                     <span class="legality-legal">
-                   {% else %}
-                     <span class="legality-unavailable">
-                   {% endif %}
-                 {% endif %}
-               </td>
+               <td style="text-align: center">{% if cycle.standard %}✓{% endif %}</td>
+               <td style="text-align: center">{% if cycle.startup %}✓{% endif %}</td>
+               <td style="text-align: center">{% if cycle.eternal %}✓{% endif %}</td>
             </tr>
             {% if cycle.packs is defined %}
                {% for pack in cycle.packs %}
@@ -72,20 +58,9 @@
                      <td data-th="Date">
                         {{ pack.available }}
                      </td>
-                     <td style="text-align: center">
-                       {% if pack.standard %}
-                         <span class="legality-legal">
-                       {% else %}
-                         <span class="legality-unavailable">
-                       {% endif %}
-                     </td>
-                     <td style="text-align: center">
-                       {% if pack.startup %}
-                         <span class="legality-legal">
-                       {% else %}
-                         <span class="legality-unavailable">
-                       {% endif %}
-                     </td>
+                     <td style="text-align: center">{% if pack.standard %}✓{% endif %}</td>
+                     <td style="text-align: center">{% if pack.startup %}✓{% endif %}</td>
+                     <td style="text-align: center">{% if cycle.eternal %}✓{% endif %}</td>
                   </tr>
                {% endfor %}
             {% endif %}

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -144,7 +144,7 @@
                                     {% if mwl_info.active %}
                                       class="legality-{{ mwl_info.legality }}"
                                     {% endif %}
-                                  {% endfor %}> Standard Ban List<span>
+                                  {% endfor %}> Standard Ban List</span>
                                   <a id="mwl-history" href="">(show history)</a>
                             </th>
                         </tr>

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -144,7 +144,7 @@ class CardsData
         $list_cycles = $this->entityManager->getRepository(Cycle::class)->findBy([], ["position" => "DESC"]);
         $non_standard_packs = ['draft', 'napd'];
         $startup_cycles = ['system-gateway', 'system-update-2021', 'ashes', 'borealis'];
-        $non_eternal_cycles = ['draft', 'napd', 'tdc'];
+        $non_eternal_packs = ['draft', 'napd', 'tdc'];
         $cycles = [];
         foreach ($list_cycles as $cycle) {
             $packs = [];
@@ -166,7 +166,7 @@ class CardsData
                     "icon"      => $pack->getCycle()->getCode(),
                     "standard"  => !$pack->getCycle()->getRotated() && !in_array($pack->getCode(), $non_standard_packs),
                     "startup"   => in_array($pack->getCycle()->getCode(), $startup_cycles),
-                    "eternal"   => !in_array($pack->getCycle()->getCode(), $non_eternal_cycles),
+                    "eternal"   => !in_array($pack->getCode(), $non_eternal_packs),
                 ];
             }
 
@@ -185,7 +185,7 @@ class CardsData
                     "icon"   => $cycle->getCode(),
                     "standard" => !$cycle->getRotated(),
                     "startup"  => in_array($cycle->getCode(), $startup_cycles),
-                    "eternal"  => !in_array($cycle->getCode(), $non_eternal_cycles),
+                    "eternal"  => true,
                 ];
             }
         }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -142,6 +142,7 @@ class CardsData
     {
         /** @var Cycle[] $list_cycles */
         $list_cycles = $this->entityManager->getRepository(Cycle::class)->findBy([], ["position" => "DESC"]);
+        $startup_cycles = ['system-gateway', 'system-update-2021', 'ashes', 'borealis'];
         $cycles = [];
         foreach ($list_cycles as $cycle) {
             $packs = [];
@@ -161,6 +162,8 @@ class CardsData
                     "url"       => $this->router->generate('cards_list', ['pack_code' => $pack->getCode()], UrlGeneratorInterface::ABSOLUTE_URL),
                     "search"    => "e:" . $pack->getCode(),
                     "icon"      => $pack->getCycle()->getCode(),
+                    "standard"  => !$pack->getCycle()->getRotated(),
+                    "startup"   => in_array($pack->getCycle()->getCode(), $startup_cycles),
                 ];
             }
 
@@ -177,6 +180,8 @@ class CardsData
                     "search" => 'c:' . $cycle->getCode(),
                     "packs"  => $packs,
                     "icon"   => $cycle->getCode(),
+                    "standard" => !$cycle->getRotated(),
+                    "startup"  => in_array($pack->getCycle()->getCode(), $startup_cycles),
                 ];
             }
         }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -142,7 +142,9 @@ class CardsData
     {
         /** @var Cycle[] $list_cycles */
         $list_cycles = $this->entityManager->getRepository(Cycle::class)->findBy([], ["position" => "DESC"]);
+        $non_standard_packs = ['draft', 'napd'];
         $startup_cycles = ['system-gateway', 'system-update-2021', 'ashes', 'borealis'];
+        $non_eternal_cycles = ['draft', 'napd', 'tdc'];
         $cycles = [];
         foreach ($list_cycles as $cycle) {
             $packs = [];
@@ -162,8 +164,9 @@ class CardsData
                     "url"       => $this->router->generate('cards_list', ['pack_code' => $pack->getCode()], UrlGeneratorInterface::ABSOLUTE_URL),
                     "search"    => "e:" . $pack->getCode(),
                     "icon"      => $pack->getCycle()->getCode(),
-                    "standard"  => !$pack->getCycle()->getRotated(),
+                    "standard"  => !$pack->getCycle()->getRotated() && !in_array($pack->getCode(), $non_standard_packs),
                     "startup"   => in_array($pack->getCycle()->getCode(), $startup_cycles),
+                    "eternal"   => !in_array($pack->getCycle()->getCode(), $non_eternal_cycles),
                 ];
             }
 
@@ -181,7 +184,8 @@ class CardsData
                     "packs"  => $packs,
                     "icon"   => $cycle->getCode(),
                     "standard" => !$cycle->getRotated(),
-                    "startup"  => in_array($pack->getCycle()->getCode(), $startup_cycles),
+                    "startup"  => in_array($cycle->getCode(), $startup_cycles),
+                    "eternal"  => !in_array($cycle->getCode(), $non_eternal_cycles),
                 ];
             }
         }

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -661,6 +661,13 @@ ul.rulings-list blockquote {
   width: 1px;
 }
 
+/* Platform-dependent alignment */
+@media (min-width: 480px) {
+  .desktop-centered {
+    text-align: center !important;
+  }
+}
+
 /* Update log */
 #update-log {
   margin-bottom: 20px;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -571,6 +571,7 @@ ul.rulings-list blockquote {
 .legality-legal:before,
 .legality-banned:before,
 .legality-rotated:before,
+.legality-added:before,
 .legality-restricted:before,
 .legality-1-inf:before,
 .legality-3-inf:before {
@@ -604,6 +605,10 @@ ul.rulings-list blockquote {
 .legality-rotated:before {
   content: "ROTATED";
   background-color: #558DEC;
+}
+.legality-added:before {
+  content: "ADDED";
+  background-color: #577A57;
 }
 .legality-restricted:before {
   content: "RESTRICTED";

--- a/web/js/rotation.js
+++ b/web/js/rotation.js
@@ -145,12 +145,12 @@ Promise.all([NRDB.data.promise]).then(function() {
 
     _.difference(a, b).forEach(title => {
       let card = allCards[title];
-      card['diff'] = 'banned';
+      card['diff'] = 'rotated';
       diffs.push(card);
     });
     _.difference(b, a).forEach(title => {
       let card = allCards[title];
-      card['diff'] = 'legal';
+      card['diff'] = 'added';
       diffs.push(card);
     });
     diffs = diffs.sort(sorter);
@@ -159,9 +159,10 @@ Promise.all([NRDB.data.promise]).then(function() {
       let visible = false;
       $('#diffs').append(
         $('<div style="display:' + (visible ? 'block' : 'none') + '" data-title="' + card.title.replaceAll('"', '') + '" data-faction="' + card.faction.code + '" data-type="' + card.type.code + '">' +
+            '<span class="legality-' + card['diff'] + '"></span> ' +
             '<span class="icon icon-' + card.faction.code + ' influence-' + card.faction.code + '"></span>' +
             ' <img src="' + Url_TypeImage.replace('xxx', card.type.code) + '" style="height:12px" alt="'+card.type.code+'">' +
-            ' <a href="' + Routing.generate('cards_zoom', {card_code:card.code}) + '">' + card.title + '</a> <span class="legality-' + card['diff'] + '"></span></div>')
+            ' <a href="' + Routing.generate('cards_zoom', {card_code:card.code}) + '">' + card.title + '</a></div>')
       );
     });
     update_filter();
@@ -186,7 +187,7 @@ Promise.all([NRDB.data.promise]).then(function() {
     let rotatedCycles = rotations[e.target.value]['rotated_cycles'];
     _.sortBy(NRDB.data.cycles.find(), 'position').reverse().forEach(function (cycle) {
       var packs = _.sortBy(NRDB.data.packs.find({cycle_code:cycle.code}), 'position').reverse();
-      if (cycle.code !== 'draft' && !(cycle.code in rotatedCycles)) {    
+      if (cycle.code !== 'draft' && !(cycle.code in rotatedCycles)) {
         packs.forEach(function (pack) {
           // Terminal Directive Campaign cards are irrelevant for rotation purposes.
           if (pack.code != 'tdc') {


### PR DESCRIPTION
- Rotation page now has indicators listed before their cards to ensure they line up nicely
- Rotation page now uses "added" and "rotated" instead of "legal" and "banned" (resolves #632)
- Added a column to the sets page that shows which formats (Standard, Startup, and Eternal) each cycle/data pack is legal in (resolves #567)

![image](https://user-images.githubusercontent.com/26557961/169136133-f304fc2b-aff4-455a-8833-eaa79f6024f6.png)
![image](https://user-images.githubusercontent.com/26557961/169136172-4860ca1c-4aea-4ab0-857d-4aeb405e6213.png)
![image](https://user-images.githubusercontent.com/26557961/169136472-73a6bf87-d8cb-4c31-868e-37420ecf32fd.png)
