### PR TITLE
Fixed some differences between the search syntax page and the deckbuilder search

### DIFF
--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -24,9 +24,9 @@
             <li><code>x</code> &ndash; text</li>
             <li><code>a</code> &ndash; flavor text</li>
             <li><code>e</code> &ndash; set</li>
-            <li><code>c</code> &ndash; cycle</li>
+            <li><code>c</code> &ndash; cycle <em>(not available in deckbuilding)</em></li>
             <li><code>t</code> &ndash; type</li>
-            <li><code>f</code> &ndash; faction</li>
+            <li><code>f</code> &ndash; faction <em>(not available in deckbuilding)</em></li>
             <li><code>s</code> &ndash; subtype</li>
             <li><code>d</code> &ndash; side</li>
             <li><code>i</code> &ndash; illustrator</li>
@@ -38,11 +38,11 @@
             <li><code>p</code> &ndash; strength</li>
             <li><code>v</code> &ndash; agenda points</li>
             <li><code>h</code> &ndash; trash cost</li>
-            <li><code>r</code> &ndash; release date</li>
+            <li><code>r</code> &ndash; release date <em>(not available in deckbuilding)</em></li>
             <li><code>u</code> &ndash; unique</li>
-            <li><code>y</code> &ndash; quantity (per containing set)</li>
-            <li><code>b</code> &ndash; ban list</li>
-            <li><code>z</code> &ndash; rotation</li>
+            <li><code>y</code> &ndash; quantity printed in set</li>
+            <li><code>b</code> &ndash; ban list <em>(not available in deckbuilding)</em></li>
+            <li><code>z</code> &ndash; rotation <em>(not available in deckbuilding)</em></li>
           </ul>
         </li>
         <li>an <b>operator</b> is either:

--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -40,6 +40,7 @@
             <li><code>h</code> &ndash; trash cost</li>
             <li><code>r</code> &ndash; release date</li>
             <li><code>u</code> &ndash; unique</li>
+            <li><code>y</code> &ndash; quantity (per containing set)</li>
             <li><code>b</code> &ndash; ban list</li>
             <li><code>z</code> &ndash; rotation</li>
           </ul>

--- a/app/Resources/views/Default/syntax.html.twig
+++ b/app/Resources/views/Default/syntax.html.twig
@@ -32,6 +32,7 @@
             <li><code>i</code> &ndash; illustrator</li>
             <li><code>o</code> &ndash; cost</li>
             <li><code>g</code> &ndash; advancement cost</li>
+            <li><code>l</code> &ndash; base link</li>
             <li><code>m</code> &ndash; memory usage</li>
             <li><code>n</code> &ndash; influence (faction cost)</li>
             <li><code>p</code> &ndash; strength</li>

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -491,6 +491,27 @@ class CardsData
                     }
                     $clauses[] = implode($operator == '!' ? " and " : " or ", $or);
                     break;
+                case 'l': // baselink
+                    $or = [];
+                    foreach ($condition as $arg) {
+                        switch ($operator) {
+                            case ':':
+                                $or[] = "(c.baseLink = ?$i)";
+                                break;
+                            case '!':
+                                $or[] = "(c.baseLink != ?$i)";
+                                break;
+                            case '<':
+                                $or[] = "(c.baseLink < ?$i)";
+                                break;
+                            case '>':
+                                $or[] = "(c.baseLink > ?$i)";
+                                break;
+                        }
+                        $parameters[$i++] = $arg;
+                    }
+                    $clauses[] = implode($operator == '!' ? " and " : " or ", $or);
+                    break;
                 case 'm': // memoryunits
                     $or = [];
                     foreach ($condition as $arg) {

--- a/web/js/nrdb.smart_filter.js
+++ b/web/js/nrdb.smart_filter.js
@@ -51,6 +51,9 @@
       case "v":
         add_integer_sf('agenda_points', operator, values);
         break;
+      case "l":
+        add_integer_sf("base_link", operator, values);
+        break;
       case "n":
         add_integer_sf('faction_cost', operator, values);
         break;

--- a/web/js/nrdb.smart_filter.js
+++ b/web/js/nrdb.smart_filter.js
@@ -20,18 +20,6 @@
       var values = condition;
 
       switch (type) {
-      case "e":
-        add_string_sf('pack_code', operator, values);
-        break;
-/*      case "c":
-        add_integer_sf('cyclenumber', operator, values);
-        break;
-      case "f":
-        add_string_sf('faction_letter', operator, values);
-        break;
-*/      case "t":
-        add_string_sf('type_code', operator, values);
-        break;
       case "":
       case "_":
         add_string_sf('title', operator, values);
@@ -42,17 +30,35 @@
       case "a":
         add_string_sf('flavor', operator, values);
         break;
+      case "e":
+        add_string_sf('pack_code', operator, values);
+        break;
+      // case "c":
+      //   add_integer_sf('cyclenumber', operator, values);
+      //   break;
+      case "t":
+        add_string_sf('type_code', operator, values);
+        break;
+      // case "f":
+      //   add_string_sf('faction_letter', operator, values);
+      //   break;
       case "s":
         add_string_sf('keywords', operator, values);
+        break;
+      case "i":
+        add_string_sf('illustrator', operator, values);
         break;
       case "o":
         add_integer_sf('cost', operator, values);
         break;
-      case "v":
-        add_integer_sf('agenda_points', operator, values);
+      case "g":
+        add_integer_sf('advancement_cost', operator, values);
         break;
       case "l":
         add_integer_sf("base_link", operator, values);
+        break;
+      case "m":
+        add_integer_sf("memory_cost", operator, values);
         break;
       case "n":
         add_integer_sf('faction_cost', operator, values);
@@ -60,17 +66,17 @@
       case "p":
         add_integer_sf('strength', operator, values);
         break;
-      case "g":
-        add_integer_sf('advancement_cost', operator, values);
+      case "v":
+        add_integer_sf('agenda_points', operator, values);
         break;
       case "h":
         add_integer_sf('trash_cost', operator, values);
         break;
-      case "y":
-        add_integer_sf('quantity', operator, values);
-        break;
       case "u":
         add_boolean_sf('uniqueness', operator, values);
+        break;
+      case "y":
+        add_integer_sf('quantity', operator, values);
         break;
       }
     }

--- a/web/js/nrdb.smart_filter.js
+++ b/web/js/nrdb.smart_filter.js
@@ -19,6 +19,8 @@
       var operator = condition.shift();
       var values = condition;
 
+      /* NOTE: some parameters are missing (e.g. faction, cycle number) because
+       * they interact weird with the UI. */
       switch (type) {
       case "":
       case "_":
@@ -33,15 +35,9 @@
       case "e":
         add_string_sf('pack_code', operator, values);
         break;
-      // case "c":
-      //   add_integer_sf('cyclenumber', operator, values);
-      //   break;
       case "t":
         add_string_sf('type_code', operator, values);
         break;
-      // case "f":
-      //   add_string_sf('faction_letter', operator, values);
-      //   break;
       case "s":
         add_string_sf('keywords', operator, values);
         break;


### PR DESCRIPTION
- Added MU cost and illustrator as valid search parameters in deckbuilding
- Documented `y` (quantity) in the syntax help page
- Reordered queries in the js search function to match the search syntax page
- Added a query for base link in runner IDs (e.g. `l:2` gets only Sunny)