### PR TITLE
Fix n search op (deckbuilder was fine) to deal with 0 influence cards.

### DIFF
--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -538,16 +538,16 @@ class CardsData
                     foreach ($condition as $arg) {
                         switch ($operator) {
                             case ':':
-                                $or[] = "(c.factionCost = ?$i or c.influenceLimit =?$i)";
+                                $or[] = "((t.id != 9 AND COALESCE(c.factionCost, 0) = ?$i) or (t.id = 9 AND COALESCE(c.influenceLimit, 0) =?$i))";
                                 break;
                             case '!':
-                                $or[] = "(c.factionCost != ?$i or c.influenceLimit != ?$i)";
+                                $or[] = "((t.id != 9 AND COALESCE(c.factionCost, 0) != ?$i) or (t.id = 9 AND COALESCE(c.influenceLimit, 0) != ?$i))";
                                 break;
                             case '<':
-                                $or[] = "(c.factionCost < ?$i or c.influenceLimit < ?$i)";
+                                $or[] = "((t.id != 9 AND COALESCE(c.factionCost, 0) < ?$i) or (t.id = 9 AND COALESCE(c.influenceLimit, 0) < ?$i))";
                                 break;
                             case '>':
-                                $or[] = "(c.factionCost > ?$i or c.influenceLimit > ?$i)";
+                                $or[] = "((t.id != 9 AND COALESCE(c.factionCost, 0) > ?$i) or (t.id = 9 AND COALESCE(c.influenceLimit, 0) > ?$i))";
                                 break;
                         }
                         $parameters[$i++] = $arg;


### PR DESCRIPTION
Thanks to @distributive for reporting this and the folks @ GLC for finding it.

We weren't handling this properly on the server-side search, but the deckbuilder was OK.
Before:

<img width="1222" alt="Screen Shot 2022-06-06 at 10 56 06 PM" src="https://user-images.githubusercontent.com/396562/172292683-dba1c901-3893-4172-b1db-5c5d8039190e.png">

<img width="1180" alt="Screen Shot 2022-06-06 at 10 56 46 PM" src="https://user-images.githubusercontent.com/396562/172292764-7e9e8daa-1cf8-4a35-9b5f-341600e226f2.png">


After:

<img width="1202" alt="Screen Shot 2022-06-06 at 10 52 12 PM" src="https://user-images.githubusercontent.com/396562/172292576-3012158c-4f00-47bb-9179-b73c7201517d.png">

<img width="1193" alt="Screen Shot 2022-06-06 at 10 52 24 PM" src="https://user-images.githubusercontent.com/396562/172292593-f1a633f9-fb4c-4b33-a72b-ea20063a2a16.png">

