### PR TITLE
Made Midnight Sun illegal for constructed play

### DIFF
--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -142,9 +142,10 @@ class CardsData
     {
         /** @var Cycle[] $list_cycles */
         $list_cycles = $this->entityManager->getRepository(Cycle::class)->findBy([], ["position" => "DESC"]);
-        $non_standard_packs = ['draft', 'napd'];
+        $non_standard_packs = ['draft', 'napd', 'ms'];
         $startup_cycles = ['system-gateway', 'system-update-2021', 'ashes', 'borealis'];
-        $non_eternal_packs = ['draft', 'napd', 'tdc'];
+        $non_startup_cycles = ['ms'];
+        $non_eternal_packs = ['draft', 'napd', 'tdc', 'ms'];
         $cycles = [];
         foreach ($list_cycles as $cycle) {
             $packs = [];
@@ -165,7 +166,7 @@ class CardsData
                     "search"    => "e:" . $pack->getCode(),
                     "icon"      => $pack->getCycle()->getCode(),
                     "standard"  => !$pack->getCycle()->getRotated() && !in_array($pack->getCode(), $non_standard_packs),
-                    "startup"   => in_array($pack->getCycle()->getCode(), $startup_cycles),
+                    "startup"   => in_array($pack->getCycle()->getCode(), $startup_cycles) && !in_array($pack->getCode(), $non_startup_cycles),
                     "eternal"   => !in_array($pack->getCode(), $non_eternal_packs),
                 ];
             }

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -183,6 +183,7 @@ function create_collection_tab(initialPackSelection) {
   NRDB.data.cycles.find( { "rotated": true } ).forEach(function(cycle) { rotated_cycles[cycle.code] = 1; });
 
   var rotated_packs = Array();
+  rotated_packs['ms'] = 1;
   NRDB.data.packs.find().forEach(function(pack) { if (rotated_cycles[pack.cycle.code]) { rotated_packs[pack.code] = 1; } });
 
   $('#collection_startup').on('click', function(event) {


### PR DESCRIPTION
Well, technically you can still put it in a deck and publish it, but this makes it clearer that you're not meant to.

- Deckbuilder now omits Midnight Sun
- The sets page no longer lists it as legal in any format