### PR TITLE
Added a border radius to card images in card pages

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -141,7 +141,7 @@ body {font-size:16px;font-family: 'LatoWeb', sans-serif;}
 .qtip-nrdb .card-image-corp-operation { background-size:105px; background-position: -1px -2px }
 .qtip-nrdb .card-image-corp-upgrade { background-size:105px; background-position: -4px 8px }
 .qtip-nrdb .card-image-corp-ice { background-size:115px; background-position: -9px -77px;transform: rotate(90deg) ;-webkit-transform: rotate(90deg) ;-moz-transform: rotate(90deg) ;-o-transform: rotate(90deg) ;-ms-transform: rotate(90deg)}
-
+.card-image img { border-radius: 15px; }
 
 article.rules aside{border-left:1px solid blue;padding-left:20px}
 article.rules span.anr{font-style:italic;white-space:nowrap}


### PR DESCRIPTION
This adds a border radius to card images on card pages, removing the non-transparent corners.

Examples:
![image](https://user-images.githubusercontent.com/26557961/177219811-eb9ec12e-141e-47d2-9c08-47c1463188ae.png)
![image](https://user-images.githubusercontent.com/26557961/177219727-810ceb83-7da7-4624-94bb-928c6b4feeca.png)

