### PR TITLE
Fix display of multiple illustrators.

### DIFF
--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -95,10 +95,12 @@
                 {% if card.illustrator %}
                     <div class="card-illustrator">
                         <small>
-                            Illustrated by
-                                {% for illustrator in card.illustrators %}
-                                    <a href="{{ path('cards_find',{type:'find',_locale:app.request.locale,'view':'images','q':'i:"' ~ illustrator ~ '"'}) }}">{{ illustrator }}</a>
-                                {% endfor %}
+                            Illustrated by {{
+                                card.illustrators |
+                                map(i => "<a href=\"#{ path('cards_find',{type:'find',_locale:app.request.locale,'view':'images','q':'i:"' ~ i ~ '"'}) }\">#{i}</a>") |
+                                join(', ') |
+                                raw
+                            }}
                             </a>
                         </small>
                     </div>

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -816,7 +816,7 @@ class CardsData
             "faction_cost_dots" => $card->getFactionCostDots(),
             "flavor"            => $card->getFlavor(),
             "illustrator"       => $card->getIllustrator(),
-            "illustrators"      => $this->illustrators->split($card->getIllustrator()),
+            "illustrators"      => explode(', ', $card->getIllustrator()),
             "influencelimit"    => $card->getInfluenceLimit(),
             "memoryunits"       => $card->getMemoryCost(),
             "minimumdecksize"   => $card->getMinimumDeckSize(),


### PR DESCRIPTION
Each illustrator is now consistently separated by ", ".  In the view, split on that and link each name independently.