### PR TITLE
Brain/core interchangeability

### DIFF
--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -290,7 +290,6 @@ class CardsData
                     $or = [];
                     // Apply text aliases
                     foreach ($textAliases as $alias => $replacement) {
-                        print ($alias . " " . $replacement . " - ");
                         foreach ($condition as $arg) {
                             if (str_contains($arg, $alias)) {
                                 array_push($condition, str_replace($alias, $replacement, $arg));

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -241,6 +241,13 @@ class CardsData
            ->leftJoin('c.faction', 'f')
            ->leftJoin('c.side', 's');
 
+        // Text aliases
+        // Currently only for combining results for "brain damage" with results for "core damage" and vice versa
+        $textAliases = [
+            "brain d" => "core d",
+            "core d" => "brain d"
+        ];
+
         $qb2 = null;
         $qb3 = null;
         $clauses = [];
@@ -281,6 +288,16 @@ class CardsData
                     break;
                 case 'x': // text
                     $or = [];
+                    // Apply text aliases
+                    foreach ($textAliases as $alias => $replacement) {
+                        print ($alias . " " . $replacement . " - ");
+                        foreach ($condition as $arg) {
+                            if (str_contains($arg, $alias)) {
+                                array_push($condition, str_replace($alias, $replacement, $arg));
+                            }
+                        }
+                    }
+
                     foreach ($condition as $arg) {
                         switch ($operator) {
                             case ':':


### PR DESCRIPTION
This makes it so that searching for "brain damage" or "core damage" in a card's text will get results for both terms. For versatility it specifically looks for "brain d" or "core d", but not "brain" or "core" alone as those would get false matches (e.g. agendas with on-score abilities).