### PR TITLE
Adding set icon/numbers to cards in deck comparison

### DIFF
--- a/web/js/decks.v2.js
+++ b/web/js/decks.v2.js
@@ -128,7 +128,7 @@ function do_diff(uuids) {
   var item_data = $.map(intersect, function(qty, card_code) {
     var card = NRDB.data.cards.findById(card_code);
     if(card) return { card: card, qty: qty };
-  }).sort(function (a, b) { return a.title.localeCompare(b.title); });
+  }).sort(function (a, b) { return a.card.title.localeCompare(b.card.title); });
   $.each(item_data, function (index, item) {
     list.append(get_card_list_item_html(item.card, item.qty));
   });
@@ -139,7 +139,7 @@ function do_diff(uuids) {
     var item_data = $.map(listings[i], function(qty, card_code) {
       var card = NRDB.data.cards.findById(card_code);
       if(card) return { card: card, qty: qty };
-    }).sort(function (a, b) { return a.title.localeCompare(b.title); });
+    }).sort(function (a, b) { return a.card.title.localeCompare(b.card.title); });
     $.each(item_data, function (index, item) {
       list.append(get_card_list_item_html(item.card, item.qty));
     });

--- a/web/js/decks.v2.js
+++ b/web/js/decks.v2.js
@@ -97,6 +97,10 @@ function decks_upload_all() {
   $('#archiveModal').modal('show');
 }
 
+function get_card_list_item_html(card, quantity) {
+  return '<li>'+quantity+'x '+card.title+' (<span class="small icon icon-' + card.pack.cycle.code + '"></span> ' + card.position + ')</li>';
+}
+
 function do_diff(uuids) {
   if(uuids.length < 2) return;
 
@@ -121,23 +125,23 @@ function do_diff(uuids) {
   container.empty();
   container.append("<h4>Cards in all decks</h4>");
   var list = $('<ul></ul>').appendTo(container);
-  var cards = $.map(intersect, function(qty, card_code) {
+  var item_data = $.map(intersect, function(qty, card_code) {
     var card = NRDB.data.cards.findById(card_code);
-    if(card) return { title: card.title, qty: qty };
+    if(card) return { card: card, qty: qty };
   }).sort(function (a, b) { return a.title.localeCompare(b.title); });
-  $.each(cards, function (index, card) {
-    list.append('<li>'+card.title+' x'+card.qty+'</li>');
+  $.each(item_data, function (index, item) {
+    list.append(get_card_list_item_html(item.card, item.qty));
   });
 
   for(var i=0; i<listings.length; i++) {
     container.append("<h4>Cards only in <b>"+names[i]+"</b></h4>");
     var list = $('<ul></ul>').appendTo(container);
-    var cards = $.map(listings[i], function(qty, card_code) {
+    var item_data = $.map(listings[i], function(qty, card_code) {
       var card = NRDB.data.cards.findById(card_code);
-      if(card) return { title: card.title, qty: qty };
+      if(card) return { card: card, qty: qty };
     }).sort(function (a, b) { return a.title.localeCompare(b.title); });
-    $.each(cards, function (index, card) {
-      list.append('<li>'+card.title+' x'+card.qty+'</li>');
+    $.each(item_data, function (index, item) {
+      list.append(get_card_list_item_html(item.card, item.qty));
     });
   }
   $('#diffModal').modal('show');
@@ -205,7 +209,7 @@ function do_diff_collection(uuids) {
   var list = $('<ul></ul>').appendTo(container);
   $.each(intersect, function (card_code, qty) {
     var card = NRDB.data.cards.findById(card_code);
-    if(card) list.append('<li>'+card.title+' x'+qty+'</li>');
+    if(card) list.append(get_card_list_item_html(card, qty));
   });
 
   for(var i=0; i<listings.length; i++) {
@@ -213,7 +217,7 @@ function do_diff_collection(uuids) {
     var list = $('<ul></ul>').appendTo(container);
     $.each(listings[i], function (card_code, qty) {
       var card = NRDB.data.cards.findById(card_code);
-      if(card) list.append('<li>'+card.title+' x'+qty+'</li>');
+      if(card) list.append(get_card_list_item_html(card, qty));
     });
   }
   $('#diffModal').modal('show');

--- a/web/js/decks.v2.js
+++ b/web/js/decks.v2.js
@@ -98,7 +98,7 @@ function decks_upload_all() {
 }
 
 function get_card_list_item_html(card, quantity) {
-  return '<li>'+quantity+'x '+card.title+' (<span class="small icon icon-' + card.pack.cycle.code + '"></span> ' + card.position + ')</li>';
+  return '<li>' + quantity + 'x ' + card.title + ' (<span class="small icon icon-' + card.pack.cycle.code + '"></span> ' + card.position + ')</li>';
 }
 
 function do_diff(uuids) {


### PR DESCRIPTION
Hello there! First time contributor here. Got into Netrunner recently and just starting to get familiar with NetrunnerDB (and GitHub itself :P), so please bear with me.

When playing around with decklists I found the 'Compare' functions in the My Decks page. I thought it was pretty cool and useful to quickly see what needs to be replaced in order to turn a physical deck into a different version of it, except that for a new player like me it's kinda hard to know where I might be able to find a particular card without knowing what its set and number is. I saw in some other parts of the site that this info is sometime displayed on card lists when they're being sorted by set, so I thought I'd propose for them to be added here.

Aside from adding the icons and set numbers, I refactored the generation of these items into its own function in that same file, hopefully making any future changes here a little bit easier and more uniform.

I was not able to set up a proper local copy of the site, but I WAS able to run the modified JS code on the prod site directly through the Chrome dev console and these were the results:
<img width="645" alt="Screen Shot 2022-07-14 at 11 46 07 PM" src="https://user-images.githubusercontent.com/4691960/179168450-9708e6fc-7940-45ab-a725-c1a939f94114.png">
<img width="646" alt="Screen Shot 2022-07-14 at 11 45 39 PM" src="https://user-images.githubusercontent.com/4691960/179168456-bcc9cc9a-eb29-41d2-9610-f336b8f5d2ac.png">
<img width="636" alt="Screen Shot 2022-07-14 at 11 45 25 PM" src="https://user-images.githubusercontent.com/4691960/179168459-9e26c910-cb41-4c7c-b483-cf43291aee52.png">
<img width="649" alt="Screen Shot 2022-07-14 at 11 42 03 PM" src="https://user-images.githubusercontent.com/4691960/179168465-58a81b6c-2328-4881-a896-7922aec6459b.png">

I'd totally understand if this is something that might need more of a justification or more testing, but I thought it'd be cool to have.