### PR TITLE
Remove unused import and functions from index twig and js.

### DIFF
--- a/app/Resources/views/Default/index.html.twig
+++ b/app/Resources/views/Default/index.html.twig
@@ -1,7 +1,6 @@
 {% extends '/layout.html.twig' %}
 
 {% block head %}
-<script src="{{ asset('/js/nrdb.smart_filter.js') }}"></script>
 <script src="{{ asset('/js/index.js') }}"></script>
 
 <script type="text/javascript">

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -13,39 +13,9 @@ $(document).on('data.app', function() {
   update_deck();
 });
 
-function update_cardsearch_result() {
-  $('#card_search_results').empty();
-  var query = NRDB.smart_filter.get_query();
-  if ($.isEmptyObject(query))
-    return;
-  var tabindex = 2;
-  NRDB.data.cards.apply(window, query).order("title asec").each(
-      function(record) {
-        $('#card_search_results').append(
-            '<tr><td><span class="icon icon-' + record.faction_code
-                + ' ' + record.faction_code
-                + '"></td><td><a tabindex="'
-                + (tabindex++)
-                + '" href="'
-                + Routing.generate('cards_zoom', {card_code:record.code})
-                + '" class="card" data-index="' + record.code
-                + '">' + record.title
-                + '</a></td><td class="small">'
-                + record.pack.name + '</td></tr>');
-      });
-}
-
-function handle_input_change(event) {
-  NRDB.smart_filter.handler($(this).val(), update_cardsearch_result);
-}
-
 $(function() {
   $('#version-popover').popover({
     html : true
-  });
-
-  $('#card_search_form').on({
-    keyup : debounce(handle_input_change, 250)
   });
 
   $('#update-log a').click(function (event) {


### PR DESCRIPTION
the card search is handled via the top nav code and this is a leftover.  This lets us remove the import for smart_filter on the homepage.