### PR TITLE
Fix filtering influence for identities

### DIFF
--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -566,16 +566,16 @@ class CardsData
                     foreach ($condition as $arg) {
                         switch ($operator) {
                             case ':':
-                                $or[] = "((t.id != 9 AND COALESCE(c.factionCost, 0) = ?$i) or (t.id = 9 AND COALESCE(c.influenceLimit, 0) =?$i))";
+                                $or[] = "((t.code != 'identity' AND COALESCE(c.factionCost, 0) = ?$i) or (t.code = 'identity' AND COALESCE(c.influenceLimit, 0) =?$i))";
                                 break;
                             case '!':
-                                $or[] = "((t.id != 9 AND COALESCE(c.factionCost, 0) != ?$i) or (t.id = 9 AND COALESCE(c.influenceLimit, 0) != ?$i))";
+                                $or[] = "((t.code != 'identity' AND COALESCE(c.factionCost, 0) != ?$i) or (t.code = 'identity' AND COALESCE(c.influenceLimit, 0) != ?$i))";
                                 break;
                             case '<':
-                                $or[] = "((t.id != 9 AND COALESCE(c.factionCost, 0) < ?$i) or (t.id = 9 AND COALESCE(c.influenceLimit, 0) < ?$i))";
+                                $or[] = "((t.code != 'identity' AND COALESCE(c.factionCost, 0) < ?$i) or (t.code = 'identity' AND COALESCE(c.influenceLimit, 0) < ?$i))";
                                 break;
                             case '>':
-                                $or[] = "((t.id != 9 AND COALESCE(c.factionCost, 0) > ?$i) or (t.id = 9 AND COALESCE(c.influenceLimit, 0) > ?$i))";
+                                $or[] = "((t.code != 'identity' AND COALESCE(c.factionCost, 0) > ?$i) or (t.code = 'identity' AND COALESCE(c.influenceLimit, 0) > ?$i))";
                                 break;
                         }
                         $parameters[$i++] = $arg;


### PR DESCRIPTION
Example implementation to fix influence filter bug. I don't have a working local environment so can't vouch for this working, but wanted to offer it as an illustration.

Applying logic based on the code of the type rather than the ID makes it resistant to inconsistent IDs between environments.

Fixes #692 