### PR TITLE
Reversed operator effect on banlist searches and added Startup to the advanced search page

### DIFF
--- a/app/Resources/views/Search/advanced-search.html.twig
+++ b/app/Resources/views/Search/advanced-search.html.twig
@@ -238,6 +238,7 @@
                                 <label for="z">Rotation</label>
                                 <select class="form-control" name="z">
                                     <option value=""></option>
+                                    <option value="startup">Startup</option>
                                     {% set active_found = false %}
                                     {% set latest_found = false %}
                                     {% set today = "now"|date("Y-m-d") %}

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -719,7 +719,7 @@ class CardsData
                         $mwl = $this->entityManager->getRepository(Mwl::class)->findOneBy(['code' => $condition[0]], ["dateStart" => "DESC"]);
                     }
                     if ($mwl) {
-                        $cond = $operator == ":" ? "in" : "not in";
+                        $cond = $operator == "!" ? "in" : "not in";
                         $clauses[] = "(c.id $cond (SELECT mc.card_id FROM AppBundle:MwlCard mc WHERE mc.mwl_id = ?$i))";
                         $parameters[$i++] = $mwl->getId();
                     }


### PR DESCRIPTION
- `b:...` now gets cards legal under the given banlist instead of cards banned under that banlist
- `b!...` now gets cards banned under the given banlist

It was pointed out that the current implementation (`b:...` getting _only_ banned cards under a given list) is counter intuitive, especially within the context of the advanced search page. Ideally the new syntax in v2 will be clearer.

- Added Startup to the rotation dropdown in the advanced search page