### PR TITLE
Remove Jinteki.net mention from "Copy legacy URL" action

### DIFF
--- a/app/Resources/views/Decklist/decklist.html.twig
+++ b/app/Resources/views/Decklist/decklist.html.twig
@@ -55,7 +55,7 @@ NRDB.user.params.decklist_id = Decklist.id;
                    }, function() {
                        alert('Copy to clipboard failed. Sorry!');
                    });
-                   return false;">Copy Legacy URL for Jinteki.net</a>
+                   return false;">Copy legacy URL </a>
             </div>
             {% if duplicate %}
             | <small>Duplicate of <a href="{{ path('decklist_view', { 'decklist_uuid': duplicate.uuid, 'decklist_name': duplicate.prettyname|e('url') }) }}">{{ duplicate.name }}</a></small>


### PR DESCRIPTION
jnet has been updated to support both the legacy and the new URLs,
and someone mentioned on stimhack that legacy URLs are still needed for ABR.
I thought might as well make it generic.

I'll look into updating ABR as well.