### PR TITLE
Highlight first card suggestion during deckbuilding

### DIFF
--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -114,6 +114,8 @@ Promise.all([NRDB.data.promise, NRDB.settings.promise]).then(function() {
   }, {
     display: function(card) { return card.title + ' (' + card.pack.name + ')'; },
     source: findMatches
+  }).bind('typeahead:render', function() {
+    $('#filter-text').parent().find('.tt-selectable:first').addClass('tt-cursor');
   });
 
   make_cost_graph();


### PR DESCRIPTION
Small QOL for deckbuilding which would allow for card selection without use of mouse/Tab/Down.

I manually tested this on a local instance and didn't see any issues but I'm unfamiliar with this stack and repo so let me know if there are any tests I should be running.