### PR TITLE
Show visible errors for out of faction agendas.

### DIFF
--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -65,6 +65,7 @@ var Filters = {},
     <div id="restricted"></div>
     <div id="limited"></div>
     <div id="ampere_agenda_limit"></div>
+    <div id="out_of_faction_agendas"></div>
     <div id="rotated"></div>
   </div><!-- /.col-sm-9 -->
 </div><!-- /.row -->

--- a/app/Resources/views/Builder/decks.html.twig
+++ b/app/Resources/views/Builder/decks.html.twig
@@ -146,6 +146,7 @@ var Identity = null,
   <div id="restricted"></div>
   <div id="limited"></div>
   <div id="ampere_agenda_limit"></div>
+  <div id="out_of_faction_agendas"></div>
   <!-- Identity and Stats -->
 
   <!-- Deck Content -->

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -552,7 +552,7 @@ ul.rulings-list blockquote {
   padding: 5px 10px;
 }
 
-#restricted:not(:empty), #rotated:not(:empty), #limited:not(:empty), #ampere_agenda_limit:not(:empty) {
+#restricted:not(:empty), #rotated:not(:empty), #limited:not(:empty), #out_of_faction_agendas:not(:empty), #ampere_agenda_limit:not(:empty) {
   color: red;
   display: list-item;
   list-style-type: disc;

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -266,6 +266,7 @@ function create_collection_tab(initialPackSelection) {
     }
   });
 
+  // Create elements for faction and card type selectors.
   $('.filter').each(function(index, div) {
     var columnName = $(div).attr('id');
     var arr = [];
@@ -670,6 +671,8 @@ function handle_quantity_change(event) {
         });
     });
     refresh_collection();
+    // This is the magic incantation that allows the card quantity to update correctly when changing IDs.
+    $('#mwl_code').trigger('change');
   } else {
     $.each(CardDivs, function(nbcols, rows) {
       // rows is an array of card rows

--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -493,6 +493,7 @@ function update_deck(options) {
     check_influence(influenceSpent);
     check_restricted();
     check_deck_limit();
+    check_agenda_factions();
     check_ampere_agenda_limits();
     if (NRDB.settings && NRDB.settings.getItem('check-rotation')) {
         check_rotation();
@@ -505,6 +506,22 @@ function update_deck(options) {
         setTimeout(make_strength_graph, 100);
 }
 
+function check_agenda_factions() {
+    let problem = false;
+    if (Identity.faction_code != 'neutral-corp' && MWL) {
+        NRDB.data.cards.find({ indeck: { '$gt': 0 }, type_code: 'agenda', faction_code: { '$ne': 'neutral-corp' } }).forEach(function (card) {
+            if (card.faction_code != Identity.faction_code) {
+                problem = true;
+            }
+        });
+    }
+
+    if (problem) {
+        $('#out_of_faction_agendas').text('Deck includes out of faction agendas.').show();
+    } else {
+        $('#out_of_faction_agendas').text('').hide();
+    }
+}
 function check_ampere_agenda_limits() {
     if (Identity.code != '33128' /* Ampere */) {
         return;


### PR DESCRIPTION
If the banlist is casual the table should show out of faction agendas, but i'll do that in a follow PR.

Partial fix for #716 
<img width="695" alt="Screenshot 2022-12-10 at 2 09 46 PM" src="https://user-images.githubusercontent.com/396562/206873688-a4e52699-02cd-4765-8985-cfee1159ea15.png">
<img width="511" alt="Screenshot 2022-12-10 at 2 09 55 PM" src="https://user-images.githubusercontent.com/396562/206873690-fd86db84-99b4-43e4-956d-55229054e86f.png">
