### PR TITLE
prefer prefix match in autocomplete

### DIFF
--- a/app/Resources/views/Search/advanced-search.html.twig
+++ b/app/Resources/views/Search/advanced-search.html.twig
@@ -32,7 +32,7 @@
                 function normalizeTitle(cardTitle) {
                     return _.deburr(cardTitle).toLowerCase().trim();
                 }
-                var matchingCards = _.filter(all_cards, function (card) {
+                var matchingCards = _.filter(latest_cards, function (card) {
                     return regexp.test(normalizeTitle(card.title));
                 });
                 matchingCards.sort((card1, card2) => {

--- a/app/Resources/views/Search/advanced-search.html.twig
+++ b/app/Resources/views/Search/advanced-search.html.twig
@@ -32,7 +32,16 @@
                 var matchingCards = _.filter(latest_cards, function (card) {
                     return regexp.test(_.deburr(card.title).toLowerCase().trim());
                 });
-                cb(_.sortBy(matchingCards, 'title'));
+                matchingCards.sort((card1, card2) => {
+                    if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+                        return -1;
+                    }
+                    if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+                        return 1;
+                    }
+                    return card1.title < card2.title ? -1 : 1;
+                });
+                cb(matchingCards);
             }
 
             $('#q').typeahead({

--- a/app/Resources/views/Search/advanced-search.html.twig
+++ b/app/Resources/views/Search/advanced-search.html.twig
@@ -29,14 +29,20 @@
                 if (q.match(/^\w:/)) { return; }
 
                 var regexp = new RegExp(q, 'i');
-                var matchingCards = _.filter(latest_cards, function (card) {
-                    return regexp.test(_.deburr(card.title).toLowerCase().trim());
+                function normalizeTitle(cardTitle) {
+                    return _.deburr(cardTitle).toLowerCase().trim();
+                }
+                var matchingCards = _.filter(all_cards, function (card) {
+                    return regexp.test(normalizeTitle(card.title));
                 });
                 matchingCards.sort((card1, card2) => {
-                    if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+                    var card1title = normalizeTitle(card1.title);
+                    var card2title = normalizeTitle(card2.title);
+                    var normalizedQuery = normalizeTitle(q);
+                    if(card1title.startsWith(normalizedQuery) && !card2title.startsWith(normalizedQuery)) {
                         return -1;
                     }
-                    if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+                    if(card2title.startsWith(normalizedQuery) && !card1title.startsWith(normalizedQuery)) {
                         return 1;
                     }
                     return card1.title < card2.title ? -1 : 1;

--- a/app/Resources/views/Search/searchbar.html.twig
+++ b/app/Resources/views/Search/searchbar.html.twig
@@ -9,7 +9,16 @@
                 var matchingCards = _.filter(all_cards, function (card) {
                     return regexp.test(_.deburr(card.title).toLowerCase().trim());
                 });
-                cb(_.sortBy(matchingCards, 'title'));
+                matchingCards.sort((card1, card2) => {
+                    if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+                        return -1;
+                    }
+                    if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+                        return 1;
+                    }
+                    return card1.title < card2.title ? -1 : 1;
+                });
+                cb(matchingCards);
             }
 
             $('#search-input').typeahead({

--- a/app/Resources/views/Search/searchbar.html.twig
+++ b/app/Resources/views/Search/searchbar.html.twig
@@ -6,14 +6,20 @@
                 if (q.match(/^\w:/)) { return; }
 
                 var regexp = new RegExp(q, 'i');
+                function normalizeTitle(cardTitle) {
+                  return _.deburr(cardTitle).toLowerCase().trim();
+                }
                 var matchingCards = _.filter(all_cards, function (card) {
-                    return regexp.test(_.deburr(card.title).toLowerCase().trim());
+                    return regexp.test(normalizeTitle(card.title));
                 });
                 matchingCards.sort((card1, card2) => {
-                    if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+                    var card1title = normalizeTitle(card1.title);
+                    var card2title = normalizeTitle(card2.title);
+                    var normalizedQuery = normalizeTitle(q);
+                    if(card1title.startsWith(normalizedQuery) && !card2title.startsWith(normalizedQuery)) {
                         return -1;
                     }
-                    if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+                    if(card2title.startsWith(normalizedQuery) && !card1title.startsWith(normalizedQuery)) {
                         return 1;
                     }
                     return card1.title < card2.title ? -1 : 1;

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -106,16 +106,22 @@ Promise.all([NRDB.data.promise, NRDB.settings.promise]).then(function() {
     // TODO(plural): Make this variable initialized at page load and only updated when the collection changes instead of here on every keypress!
     var matchingPacks = NRDB.data.cards.find({maxqty: { '$gt': 0 }, side_code: Side, pack_code: Filters.pack_code || []});
     var latestCards = select_only_latest_cards(matchingPacks);
-    var regexp = new RegExp(q, 'i');
-    var matchingCards = _.filter(latestCards, function (card) {
-      return regexp.test(_.deburr(card.title).toLowerCase().trim());
-    });
 
+    var regexp = new RegExp(q, 'i');
+    function normalizeTitle(cardTitle) {
+      return _.deburr(cardTitle).toLowerCase().trim();
+    }
+    var matchingCards = _.filter(latestCards, function (card) {
+      return regexp.test(normalizeTitle(card.title));
+    });
     matchingCards.sort((card1, card2) => {
-        if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+        var card1title = normalizeTitle(card1.title);
+        var card2title = normalizeTitle(card2.title);
+        var normalizedQuery = normalizeTitle(q);
+        if(card1title.startsWith(normalizedQuery) && !card2title.startsWith(normalizedQuery)) {
             return -1;
         }
-        if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+        if(card2title.startsWith(normalizedQuery) && !card1title.startsWith(normalizedQuery)) {
             return 1;
         }
         return card1.title < card2.title ? -1 : 1;

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -110,7 +110,17 @@ Promise.all([NRDB.data.promise, NRDB.settings.promise]).then(function() {
     var matchingCards = _.filter(latestCards, function (card) {
       return regexp.test(_.deburr(card.title).toLowerCase().trim());
     });
-    cb(_.sortBy(matchingCards, 'title'));
+
+    matchingCards.sort((card1, card2) => {
+        if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+            return -1;
+        }
+        if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+            return 1;
+        }
+        return card1.title < card2.title ? -1 : 1;
+    });
+    cb(matchingCards);
   }
 
   $('#filter-text').typeahead({

--- a/web/js/search.js
+++ b/web/js/search.js
@@ -2,16 +2,23 @@ $(document).on('data.app', function() {
   var latestCards = select_only_latest_cards(NRDB.data.cards.find());
 
   function findMatches(q, cb) {
-    if(q.match(/^\w:/)) return;
+    if (q.match(/^\w:/)) { return; }
+
     var regexp = new RegExp(q, 'i');
+    function normalizeTitle(cardTitle) {
+      return _.deburr(cardTitle).toLowerCase().trim();
+    }
     var matchingCards = _.filter(latestCards, function (card) {
-      return regexp.test(_.deburr(card.title).toLowerCase().trim());
+      return regexp.test(normalizeTitle(card.title));
     });
     matchingCards.sort((card1, card2) => {
-        if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+        var card1title = normalizeTitle(card1.title);
+        var card2title = normalizeTitle(card2.title);
+        var normalizedQuery = normalizeTitle(q);
+        if(card1title.startsWith(normalizedQuery) && !card2title.startsWith(normalizedQuery)) {
             return -1;
         }
-        if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+        if(card2title.startsWith(normalizedQuery) && !card1title.startsWith(normalizedQuery)) {
             return 1;
         }
         return card1.title < card2.title ? -1 : 1;

--- a/web/js/search.js
+++ b/web/js/search.js
@@ -7,7 +7,16 @@ $(document).on('data.app', function() {
     var matchingCards = _.filter(latestCards, function (card) {
       return regexp.test(_.deburr(card.title).toLowerCase().trim());
     });
-    cb(_.sortBy(matchingCards, 'title'));
+    matchingCards.sort((card1, card2) => {
+        if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+            return -1;
+        }
+        if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+            return 1;
+        }
+        return card1.title < card2.title ? -1 : 1;
+    });
+    cb(matchingCards);
   }
 
   $('#filter-text').typeahead({

--- a/web/js/topnav.js
+++ b/web/js/topnav.js
@@ -10,7 +10,16 @@ Promise.all([NRDB.data.promise, NRDB.ui.promise]).then(function() {
     var matchingCards = _.filter(all_cards, function (card) {
       return regexp.test(_.deburr(card.title).toLowerCase().trim());
     });
-    cb(_.sortBy(matchingCards, 'title'));
+    matchingCards.sort((card1, card2) => {
+        if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+            return -1;
+        }
+        if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+            return 1;
+        }
+        return card1.title < card2.title ? -1 : 1;
+    });
+    cb(matchingCards);
   }
   $('#top_nav_card_search_menu').on('shown.bs.dropdown', function (element) {
     $("#top_nav_card_search").focus();

--- a/web/js/topnav.js
+++ b/web/js/topnav.js
@@ -7,14 +7,20 @@ Promise.all([NRDB.data.promise, NRDB.ui.promise]).then(function() {
     if (q.match(/^\w:/)) { return; }
 
     var regexp = new RegExp(q, 'i');
+    function normalizeTitle(cardTitle) {
+      return _.deburr(cardTitle).toLowerCase().trim();
+    }
     var matchingCards = _.filter(all_cards, function (card) {
-      return regexp.test(_.deburr(card.title).toLowerCase().trim());
+      return regexp.test(normalizeTitle(card.title));
     });
     matchingCards.sort((card1, card2) => {
-        if(card1.title.startsWith(q) && !card2.title.startsWith(q)) {
+        var card1title = normalizeTitle(card1.title);
+        var card2title = normalizeTitle(card2.title);
+        var normalizedQuery = normalizeTitle(q);
+        if(card1title.startsWith(normalizedQuery) && !card2title.startsWith(normalizedQuery)) {
             return -1;
         }
-        if(card2.title.startsWith(q) && !card1.title.startsWith(q)) {
+        if(card2title.startsWith(normalizedQuery) && !card1title.startsWith(normalizedQuery)) {
             return 1;
         }
         return card1.title < card2.title ? -1 : 1;


### PR DESCRIPTION
Andrej from the Metropole Grid made a [valid point](https://www.youtube.com/live/R5F65deCDkU?feature=share&t=6300) that certain cards like Ping, Lat, and Ob will never appear in the autocomplete because we do a substring search of the card title and sort by title, and they get shoved way down in the list when you look for their full name. This changes the sort comparator to prefer cards that match on the prefix over those that just match elsewhere in the substring.

I'm having trouble testing this locally as the typeahead library seems to not be firing in my local Symfony web server (even on `main`). Is there something I have to set to get this to work in the local webserver?