### PR TITLE
Added NSG-only as a deckbuilding format

### DIFF
--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -263,6 +263,7 @@ var Filters = {},
       <div class="panel-heading">Select your packs |
         <a href="#" id="collection_startup">Startup</a> |
         <a href="#" id="collection_standard">Standard</a> |
+        <a href="#" id="collection_nsg">NSG only</a> |
         <a href="#" id="collection_all">All</a> |
         <a href="#" id="collection_none">None</a></div>
       <div class="panel-body filter" id="pack_code"></div>

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -226,6 +226,27 @@ function create_collection_tab(initialPackSelection) {
     });
     update_collection_packs();
   });
+  $('#collection_nsg').on('click', function(event) {
+    let startup_cycles = Array(); // Hardcoded Startup Codes
+    startup_cycles['system-gateway'] = 1;
+    startup_cycles['system-update-2021'] = 1;
+    startup_cycles['ashes'] = 1;
+    startup_cycles['borealis'] = 1;
+    let startup_packs = Array(); // Hardcoded Startup Codes
+    startup_packs['sg'] = 1;
+    startup_packs['su21'] = 1;
+    startup_packs['df'] = 1;
+    startup_packs['urbp'] = 1;
+    startup_packs['ur'] = 1;
+    startup_packs['msbp'] = 1;
+    startup_packs['ms'] = 1;
+    startup_packs['ph'] = 1;
+    event.preventDefault();
+    $('#pack_code').find(':checkbox').each(function() {
+      $(this).prop('checked', Boolean(startup_cycles[$(this).prop('name')] || startup_packs[$(this).prop('name')]));
+    });
+    update_collection_packs();
+  });
   $('#collection_standard').on('click', function(event) {
     event.preventDefault();
     $('#pack_code').find(':checkbox').each(function() {


### PR DESCRIPTION
It includes every set that's every been legal in Startup.

![image](https://user-images.githubusercontent.com/26557961/218264051-b18291e5-1ec5-42b9-a941-d111b15faf7a.png)

System Core 19 and Salvaged Memories have been excluded as they were never released as a physical product. The Magnum Opus Reprint has been excluded because it is a direct replica of an existing FFG set.