### PR TITLE
Made casual/Startup legality an explicitly format in the deckbuilder

### DIFF
--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -100,13 +100,16 @@ var Filters = {},
   </div>
   <div class="form-group">
     <label for="mwl_code">Legality</label>
-    <select class="form-control" name="mwl_code" id="mwl_code">
+    <select class="form-control" name="format_code" id="format_code">
+      <option value="standard" selected="selected">Standard</option>
+      <option value="casual">Startup/Casual</option>
+    </select>
+    <select class="form-control" name="mwl_code" id="mwl_code" style="margin-top: 10px;">
       {% for mwl in list_mwl %}
       <option value="{{ mwl.code }}"{% if mwl.code == deck.mwl_code %} selected="selected"{% endif %}>
         {{ mwl.name }}{% if not mwl.active %}{% if mwl.dateStart %} (after {{ mwl.dateStart|date('Y-m-d') }}){% endif %}{% else %} (active){% endif %}
       </option>
-        {% endfor %}
-        <option value=""{% if deck.mwl_code == null %} selected="selected"{% endif %}>Casual Play</option>
+      {% endfor %}
     </select>
   </div>
   <button type="submit" class="btn btn-warning">Save</button>

--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -99,7 +99,13 @@ var Filters = {},
     <input type="text" class="form-control decklist-name" name="name" value="{{ deck.name }}">
   </div>
   <div class="form-group">
-    <label for="mwl_code">Legality</label>
+    <label for="mwl_code" class="visible-sm visible-xs">
+      Legality <small style="font-weight:normal; font-style:italic">(not retained on save)</small>
+    </label>
+    <label for="mwl_code" class="hidden-sm hidden-xs">
+      Legality
+      <sup data-toggle='tooltip' title='For filtering the cardpool while deckbuilding. Settings are not retained on save.'>?</sup>
+    </label>
     <select class="form-control" name="format_code" id="format_code">
       <option value="standard" selected="selected">Standard</option>
       <option value="casual">Startup/Casual</option>

--- a/app/Resources/views/Builder/deck.html.twig
+++ b/app/Resources/views/Builder/deck.html.twig
@@ -99,24 +99,17 @@ var Filters = {},
     <input type="text" class="form-control decklist-name" name="name" value="{{ deck.name }}">
   </div>
   <div class="form-group">
-    <label for="mwl_code" class="visible-sm visible-xs">
-      Legality <small style="font-weight:normal; font-style:italic">(not retained on save)</small>
-    </label>
-    <label for="mwl_code" class="hidden-sm hidden-xs">
-      Legality
-      <sup data-toggle='tooltip' title='For filtering the cardpool while deckbuilding. Settings are not retained on save.'>?</sup>
-    </label>
-    <select class="form-control" name="format_code" id="format_code">
-      <option value="standard" selected="selected">Standard</option>
-      <option value="casual">Startup/Casual</option>
-    </select>
-    <select class="form-control" name="mwl_code" id="mwl_code" style="margin-top: 10px;">
-      {% for mwl in list_mwl %}
-      <option value="{{ mwl.code }}"{% if mwl.code == deck.mwl_code %} selected="selected"{% endif %}>
-        {{ mwl.name }}{% if not mwl.active %}{% if mwl.dateStart %} (after {{ mwl.dateStart|date('Y-m-d') }}){% endif %}{% else %} (active){% endif %}
-      </option>
-      {% endfor %}
-    </select>
+    <label for="mwl_code">Banlist</label>
+    <div style="display:flex">
+      <select class="form-control" name="mwl_code" id="mwl_code">
+        {% for mwl in list_mwl %}
+        <option value="{{ mwl.code }}"{% if mwl.code == deck.mwl_code %} selected="selected"{% endif %}>
+          {{ mwl.name }}{% if not mwl.active %}{% if mwl.dateStart %} (after {{ mwl.dateStart|date('Y-m-d') }}){% endif %}{% else %} (active){% endif %}
+        </option>
+        {% endfor %}
+      </select>
+      <div class="checkbox" style="margin:6px 0 0 10px"><label><input type="checkbox" name="format-casual" data-persistence> Startup/Casual</label></div>
+    </div>
   </div>
   <button type="submit" class="btn btn-warning">Save</button>
   <button type="submit" id="btn-save-as-copy" class="btn btn-default">Save as Copy</button>

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -655,7 +655,7 @@ class BuilderController extends Controller
         $decklist_id = intval(filter_var($request->get('decklist_id'), FILTER_SANITIZE_NUMBER_INT));
         $description = trim($request->get('description'));
         $tags = explode(',', filter_var($request->get('tags'), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES));
-        $mwl_code = $request->get('mwl_code');
+        $mwl_code = $request->get('format_casual') ? null : $request->get('mwl_code');
 
         if ($deck instanceof Deck) {
             $deckManager->saveDeck($this->getUser(), $deck, $decklist_id, $name, $description, $tags, $mwl_code, $content, $source_deck ? $source_deck : null);

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -318,7 +318,7 @@ function create_collection_tab(initialPackSelection) {
 
   FilterQuery = get_filter_query(Filters);
 
-  $('#mwl_code').trigger('change');
+  update_mwl();
   // triggers a refresh_collection();
   // triggers a update_deck();
 
@@ -500,6 +500,14 @@ $(function() {
     },
     index : 1
   }]);
+  $('#format_code').on('change', function() {
+    if ($(this).val() == 'casual') {
+      $('#mwl_code').hide();
+    } else {
+      $('#mwl_code').show();
+    }
+    update_mwl();
+  });
   $('#mwl_code').on('change', update_mwl);
   $('#tbody-history').on('click', 'a[role=button]', load_snapshot);
   setInterval(autosave_interval, 1000);
@@ -708,7 +716,7 @@ function handle_quantity_change(event) {
     });
     refresh_collection();
     // This is the magic incantation that allows the card quantity to update correctly when changing IDs.
-    $('#mwl_code').trigger('change');
+    update_mwl();
   } else {
     $.each(CardDivs, function(nbcols, rows) {
       // rows is an array of card rows
@@ -750,10 +758,12 @@ function update_core_sets() {
 }
 
 function update_mwl(event) {
-  var mwl_code = $(this).val();
   MWL = null;
-  if(mwl_code) {
-    MWL = NRDB.data.mwl.findById(mwl_code);
+  if ($('#format_code').val() != 'casual') {
+    var mwl_code = $('#mwl_code').val();
+    if (mwl_code) {
+      MWL = NRDB.data.mwl.findById(mwl_code);
+    }
   }
   CardDivs = [ null, {}, {}, {} ];
   update_max_qty();

--- a/web/js/deck.v2.js
+++ b/web/js/deck.v2.js
@@ -500,12 +500,7 @@ $(function() {
     },
     index : 1
   }]);
-  $('#format_code').on('change', function() {
-    if ($(this).val() == 'casual') {
-      $('#mwl_code').hide();
-    } else {
-      $('#mwl_code').show();
-    }
+  $('input[name="format-casual"]').on('change', function() {
     update_mwl();
   });
   $('#mwl_code').on('change', update_mwl);
@@ -759,7 +754,7 @@ function update_core_sets() {
 
 function update_mwl(event) {
   MWL = null;
-  if ($('#format_code').val() != 'casual') {
+  if (!$('input[name="format-casual"]').is(':checked')) {
     var mwl_code = $('#mwl_code').val();
     if (mwl_code) {
       MWL = NRDB.data.mwl.findById(mwl_code);
@@ -769,6 +764,7 @@ function update_mwl(event) {
   update_max_qty();
   refresh_collection();
   update_deck();
+  $('#mwl_code').prop("disabled", $('input[name="format-casual"]').is(':checked'));
 }
 
 function build_div(record) {


### PR DESCRIPTION
I actually did this a while back, but for some reason never PR'd it.

This is what the relevant section of the deckbuilder now looks like:

![image](https://user-images.githubusercontent.com/26557961/219787668-9b71be75-2b74-4c04-bb27-df9ead7d91c4.png)

It hides the option for banlists if set to causal:

![image](https://user-images.githubusercontent.com/26557961/219787709-25859e39-af86-45fc-b292-ecd44cae5cc3.png)
