### PR TITLE
Indicate Verified Status on Rulings

### DIFF
--- a/app/Resources/views/Rulings/list.html.twig
+++ b/app/Resources/views/Rulings/list.html.twig
@@ -20,7 +20,7 @@
                     <h4><a id="{{ card.code }}" href="{{ path('cards_zoom', {card_code: card.code}) }}">{{ card.title }}</a> (<span class="icon icon-{{ card.pack.cycle.code }}"></span> {{ card.pack.name }}, {{card.position}})</h4>
                     <ul class="rulings-list">
                         {% for ruling in card.rulings %}
-                            <li>[{% if ruling.nsgRulesTeamVerified %}This ruling has been verified by the NSG Rules Team{% else %}This ruling has not been verified by the NSG Rules Team.{% endif %}]{{ ruling.text|raw }}</li>
+                            <li class="{% if ruling.nsgRulesTeamVerified %}legality-verified{% else %}legality-unverified{% endif %}">{{ ruling.text|raw }}</li>
                             {% endfor %}
                     </ul>
                 {% endif %}

--- a/app/Resources/views/Rulings/list.html.twig
+++ b/app/Resources/views/Rulings/list.html.twig
@@ -20,7 +20,7 @@
                     <h4><a id="{{ card.code }}" href="{{ path('cards_zoom', {card_code: card.code}) }}">{{ card.title }}</a> (<span class="icon icon-{{ card.pack.cycle.code }}"></span> {{ card.pack.name }}, {{card.position}})</h4>
                     <ul class="rulings-list">
                         {% for ruling in card.rulings %}
-                            <li>{{ ruling.text|raw }}</li>
+                            <li>[{% if ruling.nsgRulesTeamVerified %}This ruling has been verified by the NSG Rules Team{% else %}This ruling has not been verified by the NSG Rules Team.{% endif %}]{{ ruling.text|raw }}</li>
                             {% endfor %}
                     </ul>
                 {% endif %}

--- a/app/Resources/views/Rulings/list.html.twig
+++ b/app/Resources/views/Rulings/list.html.twig
@@ -20,7 +20,10 @@
                     <h4><a id="{{ card.code }}" href="{{ path('cards_zoom', {card_code: card.code}) }}">{{ card.title }}</a> (<span class="icon icon-{{ card.pack.cycle.code }}"></span> {{ card.pack.name }}, {{card.position}})</h4>
                     <ul class="rulings-list">
                         {% for ruling in card.rulings %}
-                            <li class="{% if ruling.nsgRulesTeamVerified %}legality-verified{% else %}legality-unverified{% endif %}">{{ ruling.text|raw }}</li>
+                            <li class="{% if ruling.nsgRulesTeamVerified %}legality-verified{% else %}legality-unverified{% endif %}">
+                                <em>Updated {{ ruling.dateUpdate | date("Y-m-d") }}</em>
+                                {{ ruling.text|raw }}
+                            </li>
                             {% endfor %}
                     </ul>
                 {% endif %}

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -197,7 +197,10 @@
         {% if card.rulings|length %}
         <ul class="rulings-list">
             {% for ruling in card.rulings %}
-            <li data-ruling-id="{{ ruling.id }}" data-ruling-text="{{ ruling.rawtext }}" data-ruling-nsg-rules-team-verified="{{ ruling.nsg_rules_team_verified ? 'true' : 'false'}}" class="{% if ruling.nsg_rules_team_verified %}legality-verified{% else %}legality-unverified{% endif %}">{{ ruling.text | raw }}</li>
+            <li data-ruling-id="{{ ruling.id }}" data-ruling-text="{{ ruling.rawtext }}" data-ruling-nsg-rules-team-verified="{{ ruling.nsg_rules_team_verified ? 'true' : 'false'}}" class="{% if ruling.nsg_rules_team_verified %}legality-verified{% else %}legality-unverified{% endif %}">
+                <em>Updated {{ ruling.date_update | date("Y-m-d") }}</em>
+                {{ ruling.text | raw }}
+            </li>
             {% endfor %}
         </ul>
         {% else %}

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -197,7 +197,7 @@
         {% if card.rulings|length %}
         <ul class="rulings-list">
             {% for ruling in card.rulings %}
-            <li data-ruling-id="{{ ruling.id }}" data-ruling-text="{{ ruling.rawtext }}">{{ ruling.text | raw }}</li>
+            <li data-ruling-id="{{ ruling.id }}" data-ruling-text="{{ ruling.rawtext }}" data-ruling-nsg-rules-team-verified="{{ ruling.nsg_rules_team_verified ? 'true' : 'false'}}">[{% if ruling.nsg_rules_team_verified %}This ruling has been verified by the NSG Rules Team{% else %}This ruling has not been verified by the NSG Rules Team.{% endif %}] {{ ruling.text | raw }}</li>
             {% endfor %}
         </ul>
         {% else %}
@@ -286,6 +286,9 @@
                                 <div class="well text-muted" id="add-ruling-form-preview"><small>Preview.</small></div>
                             </div>
                             <div class="col-sm-12">
+                                <input type="checkbox" id="nsg_rules_team_verified" name="nsg_rules_team_verified" value="true"> <label for="nsg_rules_team_verified">NSG Rules Team Verified Ruling?</label>
+                            </div>
+                            <div class="col-sm-12">
                                 <button type="submit" class="btn btn-primary">Submit</button>
                             </div>
                         </div>
@@ -316,6 +319,9 @@
                             </div>
                             <div class="col-sm-12">
                                 <div class="well text-muted" id="edit-ruling-form-preview"><small>Preview.</small></div>
+                            </div>
+                            <div class="col-sm-12">
+                                <input type="checkbox" id="edit-ruling-nsg-rules-team-verified" name="nsg_rules_team_verified" value="true"> <label for="edit-ruling-nsg-rules-team-verified">NSG Rules Team Verified Ruling?</label>
                             </div>
                             <div class="col-sm-12">
                                 <button type="submit" class="btn btn-primary">Submit</button>

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -197,7 +197,7 @@
         {% if card.rulings|length %}
         <ul class="rulings-list">
             {% for ruling in card.rulings %}
-            <li data-ruling-id="{{ ruling.id }}" data-ruling-text="{{ ruling.rawtext }}" data-ruling-nsg-rules-team-verified="{{ ruling.nsg_rules_team_verified ? 'true' : 'false'}}">[{% if ruling.nsg_rules_team_verified %}This ruling has been verified by the NSG Rules Team{% else %}This ruling has not been verified by the NSG Rules Team.{% endif %}] {{ ruling.text | raw }}</li>
+            <li data-ruling-id="{{ ruling.id }}" data-ruling-text="{{ ruling.rawtext }}" data-ruling-nsg-rules-team-verified="{{ ruling.nsg_rules_team_verified ? 'true' : 'false'}}" class="{% if ruling.nsg_rules_team_verified %}legality-verified{% else %}legality-unverified{% endif %}">{{ ruling.text | raw }}</li>
             {% endfor %}
         </ul>
         {% else %}

--- a/src/AppBundle/Controller/RulingController.php
+++ b/src/AppBundle/Controller/RulingController.php
@@ -40,6 +40,7 @@ class RulingController extends Controller
         $ruling->setCard($card);
         $ruling->setRawtext($rawtext);
         $ruling->setText($text);
+        $ruling->setNsgRulesTeamVerified($request->request->get('nsg_rules_team_verified') == 'true');
         $entityManager->persist($ruling);
         $entityManager->flush();
 
@@ -67,6 +68,7 @@ class RulingController extends Controller
 
         $ruling->setRawtext($rawtext);
         $ruling->setText($text);
+        $ruling->setNsgRulesTeamVerified($request->request->get('nsg_rules_team_verified') == 'true');
         $entityManager->flush();
 
         return $this->redirectToRoute('cards_zoom', ['card_code' => $ruling->getCard()->getCode()]);

--- a/src/AppBundle/Entity/Ruling.php
+++ b/src/AppBundle/Entity/Ruling.php
@@ -35,6 +35,11 @@ class Ruling implements TimestampableInterface
     private $text;
 
     /**
+     * @var boolean
+     */
+    private $nsg_rules_team_verified;
+
+    /**
      * @var Card
      */
     private $card;
@@ -87,6 +92,16 @@ class Ruling implements TimestampableInterface
     public function setText(string $text)
     {
         $this->text = $text;
+    }
+
+    public function getNsgRulesTeamVerified()
+    {
+        return $this->nsg_rules_team_verified;
+    }
+
+    public function setNsgRulesTeamVerified(bool $nsg_rules_team_verified)
+    {
+        $this->nsg_rules_team_verified = $nsg_rules_team_verified;
     }
 
     public function getCard()

--- a/src/AppBundle/Resources/config/doctrine/Ruling.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Ruling.orm.yml
@@ -38,4 +38,8 @@ AppBundle\Entity\Ruling:
         text:
             type: text
             nullable: false
-
+        nsg_rules_team_verified:
+            type: boolean
+            nullable: false
+            options:
+                default: false

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -1163,6 +1163,7 @@ class CardsData
                 'id'                      => $ruling->getId(),
                 'text'                    => $ruling->getText(),
                 'rawtext'                 => $ruling->getRawtext(),
+                'date_update'             => $ruling->getDateUpdate(),
                 'nsg_rules_team_verified' => $ruling->getNsgRulesTeamVerified(),
             ];
         }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -1160,9 +1160,10 @@ class CardsData
         $response = [];
         foreach ($rulings as $ruling) {
             $response[] = [
-                'id'      => $ruling->getId(),
-                'text'    => $ruling->getText(),
-                'rawtext' => $ruling->getRawtext(),
+                'id'                      => $ruling->getId(),
+                'text'                    => $ruling->getText(),
+                'rawtext'                 => $ruling->getRawtext(),
+                'nsg_rules_team_verified' => $ruling->getNsgRulesTeamVerified(),
             ];
         }
 

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -586,6 +586,14 @@ ul.rulings-list blockquote {
   text-align: center;
 }
 
+.legality-verified:before {
+  content: "VERIFIED";
+  background-color: #577A57;
+}
+.legality-unverified:before {
+  content: "UNVERIFIED";
+  background-color: #8F8F8F;
+}
 .legality-available:before {
   content: "LEGAL";
   background-color: #577A57;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -565,7 +565,9 @@ ul.rulings-list blockquote {
   padding: 0 2px;
 }
 
-/* Card legality indicators */
+/* Card legality and ruling verification indicators */
+.legality-verified:before,
+.legality-unverified:before,
 .legality-available:before,
 .legality-unavailable:before,
 .legality-legal:before,

--- a/web/js/zoom.js
+++ b/web/js/zoom.js
@@ -95,8 +95,11 @@ function edit_ruling(event) {
     $('#edit-ruling-card-id').val(cardId);
     var rulingId = $(this).closest('li').data('ruling-id');
     var rulingText = $(this).closest('li').data('ruling-text');
+    var nsgRulesTeamVerified = $(this).closest('li').data('ruling-nsg-rules-team-verified');
+    console.log(`nsgRulesTeamVerified == ${nsgRulesTeamVerified}`);
     $('#edit-ruling-id').val(rulingId);
     $('#edit-ruling-form-text').val(rulingText);
+    $('#edit-ruling-nsg-rules-team-verified').prop('checked', nsgRulesTeamVerified);
 
     var converter = new Markdown.Converter();
     $('#edit-ruling-form-text').on(


### PR DESCRIPTION
This adds a small schema change and updates the UI to allow indicating if a ruling is verified by the NSG rules team or not.

Display for users with silly placeholder text:
<img width="767" alt="Screenshot 2023-02-26 at 4 43 00 PM" src="https://user-images.githubusercontent.com/396562/221442023-ac234a65-69b9-4f62-a59a-5e576baf6cad.png">
<img width="1198" alt="Screenshot 2023-02-26 at 4 42 31 PM" src="https://user-images.githubusercontent.com/396562/221442025-9235e485-1d4e-41c0-9b4a-91969544bb56.png">

Display for rules editors:
<img width="632" alt="Screenshot 2023-02-26 at 12 57 17 AM" src="https://user-images.githubusercontent.com/396562/221442055-b029cc7d-949f-45a6-ac60-a333d3de861c.png">
