### PR TITLE
Add an API endpoint for current NRDB-hosted rulings.

### DIFF
--- a/src/AppBundle/Controller/PublicApi20Controller.php
+++ b/src/AppBundle/Controller/PublicApi20Controller.php
@@ -540,4 +540,23 @@ class PublicApi20Controller extends FOSRestController
         return $this->entityManager->getRepository('AppBundle:Mwl')->findAll();
       }, $request);
     }
+
+    /**
+     * Get all Ruling data
+     */
+    public function rulingsAction(Request $request)
+    {
+      $rulings = $this->entityManager->getRepository('AppBundle:Ruling')->findAll();
+
+      $out = [];
+      foreach($rulings as $r) {
+        array_push($out, [
+          'title' => $r->getCard()->getTitle(),
+          'ruling' => str_replace('\r', '', $r->getRawText()),
+          'date_update' => date_format($r->getDateUpdate(), 'Y-m-d'),
+          'nsg_rules_team_verified' => $r->getNsgRulesTeamVerified()
+        ]);
+      }
+      return $this->prepareResponseFromCache($out, count($out), new DateTime(), $request);
+    }
 }

--- a/src/AppBundle/Resources/config/routing.yml
+++ b/src/AppBundle/Resources/config/routing.yml
@@ -685,6 +685,12 @@ api_public_mwl:
     defaults:
         _controller: AppBundle:PublicApi20:mwl
 
+api_public_rulings:
+    path: /api/2.0/public/rulings
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:PublicApi20:rulings
+
 api_private_decks:
     path: /api/2.0/private/decks
     methods: [GET]


### PR DESCRIPTION
Add a basic endpoint to the *current* (v2) NRDB api to export rulings text to help automate the new rulings/API workflow.

This is not added to the API docs because we don't intend to publicize this one.  This is only intended for use for automating the rulings JSON creation until all of this is moved to the new API and a new rulings UI.