### PR TITLE
stop user submitted img to overflow container

### DIFF
--- a/web/css/style.css
+++ b/web/css/style.css
@@ -175,6 +175,7 @@ tbody .btn-group{white-space:nowrap}
 .decklist blockquote p {font-size:100%;}
 .decklist h1{border-bottom:1px solid lightgray}
 .decklist h1 img{vertical-align:text-top;margin-right:10px}
+.decklist img {max-width: 100%;}
 .social-icon-like{color:red}
 .social-icon-favorite{color:orange}
 .social-icon-comment{color:green}


### PR DESCRIPTION
When users submit images via md they can be bigger than their container (ie. current DOTW, 07/22/2023). This PR sets the max-width of images in the .decklist container without changing anything else about them.