### PR TITLE
Fixed tags being added to review comments

### DIFF
--- a/app/Resources/views/Reviews/reviews.html.twig
+++ b/app/Resources/views/Reviews/reviews.html.twig
@@ -60,7 +60,7 @@
        {% if review.comments|length %}
 
        {% for comment in review.comments %}
-       <div class="review-comment text-muted small">{{ comment.text }}
+       <div class="review-comment text-muted small">{{ comment.text|raw }}
        &mdash;
        <a title="{{ comment.author.reputation }} reputation" href="{{ path('user_profile_view', {user_id:comment.author.id,user_name:comment.author.username|e('url')}) }}" rel="author" class="username {{ comment.author.faction }}">{{ comment.author.username }}</a>
            {% if comment.author.donation > 0 %}<span class="glyphicon glyphicon-gift donator" title="NetrunnerDB Gracious Donator"></span>{% endif %}


### PR DESCRIPTION
This doesn't fix the issue of comments being saved with their special chars sanitised (meaning Netrunner symbols render as `<span class="icon icon-subroutine"></span>` in comments).

Partially fixes https://github.com/NetrunnerDB/netrunnerdb/issues/743