### PR TITLE
Enable the delete action on decklists for moderators.

### DIFF
--- a/web/js/decklist.v2.js
+++ b/web/js/decklist.v2.js
@@ -58,6 +58,7 @@ function setup_moderation(moderation_status, moderation_reason, is_moderator) {
             break;
         case 2: // MODERATION_TRASHED
             $('#btn-moderation-restore,#btn-moderation-absolve').parent().removeClass('disabled');
+            $('#btn-moderation-restore,#btn-moderation-delete').parent().removeClass('disabled');
             break;
         case 3: // MODERATION_DELETED
             $('#btn-moderation-restore').parent().removeClass('disabled');


### PR DESCRIPTION
The quite useful "Delete" action for moderators to use on spammy decklists was not actually enabled.  🤦 