### PR TITLE
Made plaintext decklist outputs more friendly to screenreaders

### DIFF
--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -549,7 +549,7 @@ function check_ampere_agenda_limits() {
 
 function check_startup_constraints() {
     if(MWL && MWL['name'].includes("Startup Ban List 24.09")){
-        const five_threes = NRDB.data.cards.find({ 
+        const five_threes = NRDB.data.cards.find({
             indeck: { '$gt': 0 },
             type_code: 'agenda'
         }).filter(function (card) {
@@ -1112,7 +1112,17 @@ function build_plaintext(deck) {
                 lines.push($(line).text().trim());
                 break;
             default:
-                lines.push($(line).text().trim());
+              let lineText = $(line).text().trim().replace("x", "");
+              let infCount = (lineText.match(/●/g)||[]).length;
+              let allianceInfCount = (lineText.match(/○/g)||[]).length;
+              lineText = lineText.replaceAll(/[●○]/g, "");
+              if (infCount > 0) {
+                lineText += `(${infCount} influence)`;
+              }
+              if (allianceInfCount > 0) {
+                lineText += `(${allianceInfCount} discounted influence)`;
+              }
+              lines.push(lineText);
         }
     });
 


### PR DESCRIPTION
Previously the plaintext data for decklists would include an `x` before each card (e.g. "3x Sure Gamble") which screenreaders would read out, making it an inaccessible feature. It also reads out the influence pips individually, so those have been simplified to plaintext.

![image](https://github.com/user-attachments/assets/a6a2a7e0-a860-470c-8c1f-ab0d3ce9753e)
