### PR TITLE
We aren't on PHP 8 yet, so we can't use str_contains.

### DIFF
--- a/src/AppBundle/Entity/Faction.php
+++ b/src/AppBundle/Entity/Faction.php
@@ -159,7 +159,7 @@ class Faction implements NormalizableInterface, TimestampableInterface, CodeName
      */
     public function getIsNeutral()
     {
-        return str_contains($this->code, 'neutral');
+        return strpos($this->code, 'neutral') !== false;
     }
 
     /**


### PR DESCRIPTION
patched on prod .  There is probably some polyfill somewhere that was hiding this from us when testing locally.  :/