### PR TITLE
Remove sql calc found rows & optimize decklist search

### DIFF
--- a/src/AppBundle/Controller/DecklistsController.php
+++ b/src/AppBundle/Controller/DecklistsController.php
@@ -99,11 +99,13 @@ class DecklistsController extends Controller
                 $this->denyAccessUnlessGranted('ROLE_MODERATOR');
                 $result = $decklistManager->trashed($start, $limit);
                 $pagetitle = "Trashed decklists";
+                $pagedescription = '';
                 break;
             case 'restored':
                 $this->denyAccessUnlessGranted('ROLE_MODERATOR');
                 $result = $decklistManager->restored($start, $limit);
                 $pagetitle = "Restored decklists";
+                $pagedescription = '';
                 break;
             case 'popular':
             default:

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -1115,6 +1115,20 @@ class SocialController extends Controller
         ]));
     }
 
+    private function getLimitedQueryRowsWithCounts(EntityManagerInterface $entityManager, string $baseQuery, int $start, int $limit, array $params) {
+
+        $dbh = $entityManager->getConnection();
+
+        $rows = $dbh->executeQuery("$baseQuery LIMIT $start, $limit", $params)->fetchAll(\PDO::FETCH_ASSOC);
+
+        $count = $dbh->executeQuery("SELECT COUNT(*) FROM ($baseQuery) AS t", $params)->fetch(\PDO::FETCH_NUM)[0];
+
+        return [
+            "rows" => $rows,
+            "count" => $count
+        ];
+    }
+
     /**
      * @param int                    $page
      * @param Request                $request
@@ -1136,10 +1150,9 @@ class SocialController extends Controller
         }
         $start = ($page - 1) * $limit;
 
-        $dbh = $entityManager->getConnection();
-
-        $comments = $dbh->executeQuery(
-            "SELECT SQL_CALC_FOUND_ROWS
+        $results = $this->getLimitedQueryRowsWithCounts(
+            $entityManager,
+            "SELECT
                c.id,
                c.text,
                c.date_creation,
@@ -1150,15 +1163,10 @@ class SocialController extends Controller
                from comment c
                join decklist d on c.decklist_id=d.id
                where c.user_id=?
-               order by date_creation desc
-               limit $start, $limit",
-            [
-                $user->getId(),
-            ]
-        )
-                        ->fetchAll(\PDO::FETCH_ASSOC);
-
-        $maxcount = $dbh->executeQuery("SELECT FOUND_ROWS()")->fetch(\PDO::FETCH_NUM)[0];
+               order by date_creation desc",
+            $start, $limit, [ $user->getId() ] );
+        $comments = $results['rows'];
+        $maxcount = $results['count'];
 
         // pagination : calcul de nbpages // currpage // prevpage // nextpage
         // à partir de $start, $limit, $count, $maxcount, $page
@@ -1218,8 +1226,9 @@ class SocialController extends Controller
 
         $dbh = $entityManager->getConnection();
 
-        $comments = $dbh->executeQuery(
-            "SELECT SQL_CALC_FOUND_ROWS
+        $results = $this->getLimitedQueryRowsWithCounts(
+            $entityManager,
+            "SELECT
                c.id,
                c.text,
                c.date_creation,
@@ -1232,12 +1241,11 @@ class SocialController extends Controller
                from comment c
                join decklist d on c.decklist_id=d.id
                join user u on c.user_id=u.id
-               order by date_creation desc
-               limit $start, $limit",
-            []
-        )->fetchAll(\PDO::FETCH_ASSOC);
-
-        $maxcount = $dbh->executeQuery("SELECT FOUND_ROWS()")->fetch(\PDO::FETCH_NUM)[0];
+               order by date_creation desc",
+            $start, $limit,
+            []);
+        $comments = $results['rows'];
+        $maxcount = $results['count'];
 
         // pagination : calcul de nbpages // currpage // prevpage // nextpage
         // à partir de $start, $limit, $count, $maxcount, $page


### PR DESCRIPTION
SQL_CALC_FOUND_ROWS is deprecated now and needed to be replaced with a query, then a followup COUNT(*) query to replace it.

While in DecklistManager, refactor the main decklist search to be much more efficient.  This avoids a costly join to our 2nd largest table (decklistslot) in favor of smaller lookups powered by indexes.