### PR TITLE
Set page limits for snapshot and restriction API calls.

### DIFF
--- a/app/Resources/views/Banlists/banlists.html.twig
+++ b/app/Resources/views/Banlists/banlists.html.twig
@@ -81,7 +81,7 @@ async function buildBanlistsView() {
   const [formats, cards, restrictions] = await Promise.all([
     fetchData(`{{ v3_api_url }}/api/v3/public/formats`).then(fs => fs.filter(f => desiredFormats.includes(f.id))),
     fetchCards(`?include=card_subtypes&filter[search]=in_restriction:true`, 250).then(splitBySide),
-    fetchData(`{{ v3_api_url }}/api/v3/public/restrictions?sort=-date_start`)
+    fetchData(`{{ v3_api_url }}/api/v3/public/restrictions?sort=-date_start&page[size]=100`)
   ]);
 
   // Remove the loading indicator

--- a/app/Resources/views/Formats/formats.html.twig
+++ b/app/Resources/views/Formats/formats.html.twig
@@ -33,7 +33,7 @@ async function buildFormatsView() {
   const [r1, r2, r3, r4, r5] = await Promise.all(
     [
       fetchJson('{{ v3_api_url }}/api/v3/public/snapshots?filter[active]=true'),
-      fetchJson('{{ v3_api_url }}/api/v3/public/restrictions'),
+      fetchJson('{{ v3_api_url }}/api/v3/public/restrictions?page[size]=100'),
       fetchJson('{{ v3_api_url }}/api/v3/public/card_cycles?sort=-date_release'),
       fetchJson('{{ v3_api_url }}/api/v3/public/card_sets?sort=-date_release'),
       fetchJson('{{ v3_api_url }}/api/v3/public/formats'),


### PR DESCRIPTION
This addresses 1 of the problems on the formats page and a problem on the banlists page.