### PR TITLE
Use neutral icon on search result list pages.

### DIFF
--- a/app/Resources/views/Search/display-list.html.twig
+++ b/app/Resources/views/Search/display-list.html.twig
@@ -23,9 +23,7 @@
       </td>
       <td data-th="Faction">
          <div class="table-cell">
-            {% if card.faction_code[:7] != 'neutral' %}
                <svg class="typeIcon" data-icon-color="{{ card.faction_code }}" aria-label="{{ card.faction_code }}"><use xlink:href="/images/icons.svg#faction-{{ card.faction_code }}"></use></svg>
-            {% endif %}
          </div>
       </td>
       <td data-th="Cost">{{ card.cost }}{{ card.advancementcost }}</td>


### PR DESCRIPTION
<img width="1197" alt="Screenshot 2025-01-20 at 11 48 47 AM" src="https://github.com/user-attachments/assets/affd0b4b-01ce-4fcc-94bb-03b4ee32aad6" />
