### PR TITLE
Centralize the list of startup cycles for PHP usage in CardsData.

### DIFF
--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -518,7 +518,6 @@ class SearchController extends Controller
                     $standard_legal = "available";
 
                     // Startup legality is currently hard-coded since the DB doesn't know anything about it.
-                    $startupCycles = ['elevation' => true, 'liberation' => true, 'system-gateway' => true]; // Hardcoded Startup Codes
                     $startup_legal = false;
 
                     $rotated_count = 0;
@@ -541,7 +540,7 @@ class SearchController extends Controller
                             ++$rotated_count;
                         }
                         // Any printing of this card in a valid Startup cycle means the card is Startup legal.
-                        if (array_key_exists($v['cycle_code'], $startupCycles) && date("Y-m-d") >= $pack->getDateRelease()->format("Y-m-d")) {
+                        if (in_array($v['cycle_code'], $cardsData->startupCyclesList()) && date("Y-m-d") >= $pack->getDateRelease()->format("Y-m-d")) {
                           $startup_legal = true;
                         }
                     }

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -138,12 +138,16 @@ class CardsData
         return $packs;
     }
 
+    public function startupCyclesList() {
+        return ['elevation', 'liberation', 'system-gateway'];
+    }
+
     public function allsetsdata()
     {
         /** @var Cycle[] $list_cycles */
         $list_cycles = $this->entityManager->getRepository(Cycle::class)->findBy([], ["position" => "DESC"]);
         $non_standard_packs = ['draft', 'napd'];
-        $startup_cycles = ['elevation', 'liberation', 'system-gateway']; // Hardcoded Startup Codes
+        $startup_cycles = $this->startupCyclesList();
         $non_startup_cycles = [];
         $non_eternal_packs = ['draft', 'napd', 'tdc'];
         $cycles = [];
@@ -729,7 +733,7 @@ class CardsData
                     $condition[0] = strtolower($condition[0]);
                     if ($condition[0] == "startup") {
                         // Add the valid cycles for startup and add them to the WHERE clause for the query.
-                        $cycles = ['system-gateway', 'system-update-2021', 'liberation']; // Hardcoded Startup Codes
+                        $cycles = $this->startupCyclesList();
                         $placeholders = array();
                         foreach($cycles as $cycle) {
                             array_push($placeholders, "?$i");


### PR DESCRIPTION
https://netrunnerdb.com/find/?q=z%3Astartup+s%3Afracter shows the problem.

Fixed results.
<img width="1187" alt="Screenshot 2025-05-01 at 9 04 05 AM" src="https://github.com/user-attachments/assets/18da39a6-16b2-47ba-abb3-a117ec0d8864" />
