### PR TITLE
</> for base link and advancement cost

### DIFF
--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -991,7 +991,7 @@ class CardsData
     public function validateConditions(array &$conditions)
     {
         // Remove invalid conditions
-        $canDoNumeric = ['c', 'e', 'h', 'm', 'n', 'o', 'p', 'r', 'v', 'y'];
+        $canDoNumeric = ['c', 'e', 'g', 'h', 'l', 'm', 'n', 'o', 'p', 'r', 'v', 'y'];
         $numeric = ['<', '>'];
         foreach ($conditions as $i => $l) {
             if (in_array($l[1], $numeric) && !in_array($l[0], $canDoNumeric)) {


### PR DESCRIPTION
Fixes #878

Also adds `l` (base link), which already had support by @distributive in #637 but wasn't included in `canDoNumeric`.