### PR TITLE
Add .mailmap to track contributors with differing email addresses/names

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,15 @@
+Alsciende <bertolini.cedric@me.com>
+Francesco Pellegrini <francesco.pelle@gmail.com>
+Francesco Pellegrini <francesco.pellegrini@prima.it>
+Jason Gessner <jason@multiply.org>
+Jason Gessner <jasongessner@Jasons-MacBook-Pro.local>
+Jason Gessner <jgessner@google.com>
+Jens Böttcher <eljenso.boettcher@gmail.com>
+Jens Böttcher <eljenso@users.noreply.github.com>
+Noah Bogart <nbogart@batterii.com>
+Noah Bogart <nbtheduke@gmail.com>
+Noah Bogart <noah.bogart@ebth.com>
+Noah Bogart <noah.bogart@hey.com>
+distributive <GitHub@ameliewd.com>
+distributive <github@ameliewd.com>
+x3N1GM4x <ianwittuk@gmail.com>


### PR DESCRIPTION
I realized that I've contributed to this repo many times with many different names and email combos. The [internet is divided](https://stackoverflow.com/questions/53629125/does-github-consider-mailmap-for-contribution-graph) about whether github supports [mailmap](https://git-scm.com/docs/gitmailmap), but I think it's worthwhile even for local exploration/summation.