### PR TITLE
Add support for Compose v2 to prepare-and-build.sh

### DIFF
--- a/docker/prepare-and-build.sh
+++ b/docker/prepare-and-build.sh
@@ -45,4 +45,9 @@ else
   ln -s "${CARDS_PATH}" netrunner-cards-json
 fi
 
-docker-compose build
+if command -v docker compose >/dev/null 2>&1
+then
+  docker compose build
+else
+  docker-compose build
+fi


### PR DESCRIPTION
This is a minor change to prepare-and-build.sh to use Compose v2 if it is installed and fall back to v1 otherwise.