### PR TITLE
Patch up the apply MWL command to be a bit simpler and actually fix the right decks.

### DIFF
--- a/src/AppBundle/Command/LegalityApplyMwlCommand.php
+++ b/src/AppBundle/Command/LegalityApplyMwlCommand.php
@@ -68,18 +68,6 @@ class LegalityApplyMwlCommand extends ContainerAwareCommand
 
             // Find all decklists that do not have a legality present for the given MWL.
             $countSql = "SELECT COUNT(id) FROM decklist WHERE id NOT IN (SELECT decklist_id FROM legality WHERE mwl_id = ?)";
-
-            // $countDql = "SELECT COUNT(d) FROM AppBundle:Decklist d WHERE d NOT IN (SELECT l.decklist.id FROM AppBundle:Legality l WHERE l.mwl_id = ?1)";
-
-            // SELECT COUNT(d)
-            //     FROM AppBundle:Decklist d
-            //     WHERE d.id NOT IN (
-            //         SELECT l
-            //         FROM AppBundle:Legality l
-            //         WHERE l.decklist=d AND l.mwl=?1
-            //     )
-            //     ORDER BY d.id DESC";
-            // $countQuery = $this->entityManager->createQuery($countDql)->setParameter(1, $mwl);
             $count = $this->entityManager->getConnection()->executeQuery($countSql, [$mwl->getId()])->fetchColumn(0);
             $output->writeln("<comment>Found $count decklists to analyze</comment>");
 


### PR DESCRIPTION
Fixes #841 

In general this + an update to this task's invocation on the prod server should keep deck legality in sync with new ban lists.