### PR TITLE
2 small improvements

### DIFF
--- a/app/Resources/views/Search/searchbar.html.twig
+++ b/app/Resources/views/Search/searchbar.html.twig
@@ -26,11 +26,11 @@
                   return _.deburr(cardTitle).toLowerCase().trim();
                 }
                 var matchingCards = _.filter(latest_cards, function (card) {
-                    return regexp.test(normalizeTitle(card.title));
+                    return regexp.test(normalizeTitle(card.stripped_title));
                 });
                 matchingCards.sort((card1, card2) => {
-                    var card1title = normalizeTitle(card1.title);
-                    var card2title = normalizeTitle(card2.title);
+                    var card1title = normalizeTitle(card1.stripped_title);
+                    var card2title = normalizeTitle(card2.stripped_title);
                     var normalizedQuery = normalizeTitle(q);
                     if(card1title.startsWith(normalizedQuery) && !card2title.startsWith(normalizedQuery)) {
                         return -1;

--- a/app/Resources/views/Search/searchbar.html.twig
+++ b/app/Resources/views/Search/searchbar.html.twig
@@ -62,7 +62,7 @@
     <div class="col-sm-4">
       <div class="input-group" style="margin-bottom:.5em">
         <input class="form-control" size="30" name="q" id="search-input"
-          tabindex="1" value="{{ q|default('') }}"
+          tabindex="1" value="{{ q != card.code? q : '' }}"
           placeholder="Card Search"
           title="{% include '/Search/searchtooltip.html.twig' %}">
         <span class="input-group-btn">

--- a/src/AppBundle/Controller/SearchController.php
+++ b/src/AppBundle/Controller/SearchController.php
@@ -624,6 +624,7 @@ class SearchController extends Controller
 
         $searchbar = $this->renderView('/Search/searchbar.html.twig', [
             "q"            => $q,
+            "card"         => $card,
             "view"         => $view,
             "sort"         => $sort,
             "sort_options" => self::SORT_OPTIONS,


### PR DESCRIPTION
1) typeahead doesn't recognize Phat in zoom view searchbar. This is because lodash _.deburr doesn't correctly deburr Phat. Fix by using card's stripped_title instead.
Live:
<img width="414" height="129" alt="image" src="https://github.com/user-attachments/assets/4f4ded14-b51b-4b31-9407-6f07c5684c4d" />

Mine:
<img width="449" height="111" alt="image" src="https://github.com/user-attachments/assets/78d238d1-2876-4d2f-9ee7-bed818559964" />

2) Don't populate zoom view searchbar with the card's code. This is exceptionally annoying because you have to backspace the code before being able to use the searchbar.
<img width="470" height="192" alt="image" src="https://github.com/user-attachments/assets/200e44f7-f0f7-4a36-a636-7c313584c722" />
