### PR TITLE
Sort by cost now sorts by cost first, then card type

### DIFF
--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -802,7 +802,7 @@ class CardsData
                 $qb->orderBy('c.side', 'DESC')->addOrderBy('c.type')->addOrderBy('c.faction');
                 break;
             case 'cost':
-                $qb->orderBy('c.type')->addOrderBy('c.cost')->addOrderBy('c.advancementCost');
+                $qb->orderBy('c.side', 'DESC')->addOrderBy('c.cost')->addOrderBy('c.advancementCost')->addOrderBy('c.type');
                 break;
             case 'strength':
                 $qb->orderBy('c.type')->addOrderBy('c.strength')->addOrderBy('c.agendaPoints')->addOrderBy('c.trashCost');


### PR DESCRIPTION
Fixes #843

Sort was unintuitively sorting by card types first before sorting by cost, which leads to confusion like above issue.

Live:
<img width="1230" height="438" alt="image" src="https://github.com/user-attachments/assets/438e2b3f-45e5-404b-b8b6-c4899b056021" />



Mine:
<img width="1481" height="619" alt="image" src="https://github.com/user-attachments/assets/e0f9305e-691b-41c9-b352-b2fe1fa34128" />

A small side effect of this fix was that without specifying side corp and runner sides were all mixed up when using this sort option. So I also sorted by side first before sorting by cost. I don't know if it's more intuitive to sort sides first. I'd like others opinion on this.

Side note I double checked the other sort options and they all looked reasonable to me.