### PR TITLE
[PNP] Cut marks, clear button, importing deck sorts it by type

### DIFF
--- a/app/Resources/views/Builder/printandplay.html.twig
+++ b/app/Resources/views/Builder/printandplay.html.twig
@@ -54,6 +54,7 @@ var CardDB, CardNames;
           <select class="form-control" name="pnp-cut-marks" data-persistence>
             <option>None</option>
             <option>Lines</option>
+            <option>Marks</option>
           </select>
         </label>
       </div>

--- a/app/Resources/views/Builder/printandplay.html.twig
+++ b/app/Resources/views/Builder/printandplay.html.twig
@@ -84,7 +84,8 @@ var CardDB, CardNames;
   </div>
   <div class="col-md-7">
     <div class="row">
-      <button id="btn-print" class="btn btn-success" disabled="disabled" onclick="do_print()" style="margin-bottom:2em">Print</button>
+      <button id="btn-print" class="btn btn-success" disabled onclick="do_print()" style="margin-bottom:2em">Print</button>
+      <button id="btn-clear" class="btn btn-danger" onclick="do_clear()" style="margin-left:0.8em;margin-bottom:2em">Clear</button>
     </div>
     <div class="row" id="preview-container"></div>
   </div>

--- a/web/js/pnp.js
+++ b/web/js/pnp.js
@@ -548,6 +548,36 @@ class PNP {
     }
   }
 
+  draw_cutmarks(padding) {
+    /* Draw non-invasive cutmarks, padding is space between mark and cards*/
+    for(let p = 1; p <= this.doc.getNumberOfPages(); p++) {
+      this.doc.setPage(p);
+      // 4 by 4 card intersection points, including corners. We will
+      // only be draw marks on corner and edge points.
+      for(let row = 0; row < 4; row++) {
+        for(let col = 0; col < 4; col++) {
+          if(row == 0) {
+            this.doc.line(this.MARGIN_LEFT + this.CARD_WIDTH*col, 0,
+                          this.MARGIN_LEFT + this.CARD_WIDTH*col, this.MARGIN_TOP - padding);
+          }
+          if(col == 0) {
+            this.doc.line(0, this.MARGIN_TOP + this.CARD_HEIGHT*row,
+                          this.MARGIN_LEFT - padding, this.MARGIN_TOP + this.CARD_HEIGHT*row);
+          }
+          if(row == 3) {
+            this.doc.line(this.MARGIN_LEFT + this.CARD_WIDTH*col, this.MARGIN_TOP + this.CARD_HEIGHT*row + padding,
+                          this.MARGIN_LEFT + this.CARD_WIDTH*col, this.page_height);
+          }
+          if(col == 3) {
+            this.doc.line(this.MARGIN_LEFT + this.CARD_WIDTH*col + padding, this.MARGIN_TOP + this.CARD_HEIGHT*row,
+                          this.page_width, this.MARGIN_TOP + this.CARD_HEIGHT*row);
+          }
+        }
+      }
+    }
+
+  }
+
   print(done_callback = null){
     /* setTimeout is a little trick to get print button spinner to work.
      * See https://stackoverflow.com/questions/779379/why-is-settimeoutfn-0-sometimes-useful */
@@ -578,8 +608,13 @@ class PNP {
         }
       }
 
-      if(this.settings.cutmarks == "Lines") {
-        this.draw_cutlines();
+      switch(this.settings.cutmarks) {
+        case "Lines":
+          this.draw_cutlines();
+          break;
+        case "Marks":
+          this.draw_cutmarks(1);
+          break;
       }
       this.doc.save();
       if(done_callback) {

--- a/web/js/pnp.js
+++ b/web/js/pnp.js
@@ -1,11 +1,10 @@
 // Potential enhancements:
 // Card preview are interactable to add or remove cards or select printings.
 // Hover over card names to see printing. Hover over card preview to select printing.
-// Options: Bleed, cut marks (not line)
+// Options: Bleed
 // Imported list sorting options
 // Drag to reorder imported list.
 // Deselect specific sets from print (for users who own sets and only care about printing certain sets).
-// Clear list button.
 // Decklist view...?
 
 /* {code: [side2_url, side3_url, ...]
@@ -101,6 +100,16 @@ Promise.all([NRDB.data.promise, NRDB.ui.promise]).then( () => {
 
 function do_import_pnp(first_time=false) {
   import_cards(first_time);
+  update_stats();
+  preview_cards();
+}
+
+function do_clear() {
+  if(!window.confirm("Are you sure you want to clear all cards?")) {
+    return;
+  }
+  imported_cards.clear_all();
+  update_imported_list();
   update_stats();
   preview_cards();
 }
@@ -240,6 +249,11 @@ var imported_cards = {};
       else if(o2.type.code == "identity") return 1;
       else return o1.type.code > o2.type.code? 1 : -1;
     });
+  }
+  
+  imported_cards.clear_all = function() {
+    imported_cards.entries = [];
+    imported_cards.errors = [];
   }
 
 }) (imported_cards);


### PR DESCRIPTION
1) Importing deck sorts the deck by type, prioritizing id - I think it's better user experience to see their ID appear first when importing their deck.
2) Non-invasive cut marks
<img width="659" height="805" alt="image" src="https://github.com/user-attachments/assets/82174c81-d9e2-4f1f-bff6-db5617d49537" />

3) Clear button. It also warns the user before clearing the list.
<img width="473" height="315" alt="image" src="https://github.com/user-attachments/assets/1412981c-20e8-4dc9-b93f-69f000c30648" />
