### PR TITLE
[PNP] Bleed

### DIFF
--- a/app/Resources/views/Builder/printandplay.html.twig
+++ b/app/Resources/views/Builder/printandplay.html.twig
@@ -67,6 +67,16 @@ var CardDB, CardNames;
           </select>
         </label>
       </div>
+      <div class="form-group">
+        <label>
+          Bleed
+          <select class="form-control" name="pnp-bleed" data-persistence>
+            <option>None</option>
+            <option>Narrow</option>
+            <option>Wide</option>
+          </select>
+        </label>
+      </div>
     </form>
   </div>
 </div> <!-- .row -->

--- a/web/js/nrdb.settings.js
+++ b/web/js/nrdb.settings.js
@@ -16,6 +16,7 @@
 
     'pnp-cut-marks': 'None',
     'pnp-page-format': 'Letter',
+    'pnp-bleed': 'None',
   };
 
   settings.load = function load() {


### PR DESCRIPTION
None, narrow and wide. 0, 3 and 6mm padding between cards. Cut lines are drawn in the middle of the bleed, while cut marks are drawn on the edges of cards. On narrow and wide bleed mode, cards are scaled down in order to guarantee a 1/4in or 6.35mm margin. 

The math gets really gnarly to review, so I'm going to provide screenshots.

### Letter, no cut marks
None:
<img width="813" height="787" alt="image" src="https://github.com/user-attachments/assets/973e56e9-4abc-4c69-bd46-150722220bb4" />
Narrow:
<img width="813" height="798" alt="image" src="https://github.com/user-attachments/assets/cd5212f9-2995-4683-8c78-2d19b360e592" />
Wide:
<img width="812" height="836" alt="image" src="https://github.com/user-attachments/assets/1f48883d-f800-4943-ad87-b7ed50e12cf8" />

### A4, cut lines
None:
<img width="789" height="839" alt="image" src="https://github.com/user-attachments/assets/04e5a1a5-9691-43e4-ae14-9d53cc56faee" />
Narrow:
<img width="786" height="855" alt="image" src="https://github.com/user-attachments/assets/14ec74b1-38fe-4edb-b691-3ac34c3c2461" />
Wide:
<img width="789" height="881" alt="image" src="https://github.com/user-attachments/assets/0902ae90-7e1b-4ede-93ee-bd16bcccc650" />

### Letter, cut marks
None:
<img width="807" height="877" alt="image" src="https://github.com/user-attachments/assets/13ad69bf-43ba-4dc0-8f3b-acf01f4f40f0" />
Narrow:
<img width="809" height="877" alt="image" src="https://github.com/user-attachments/assets/7a6def21-53fe-47a6-9609-c653a49d39a6" />
Wide:
<img width="810" height="880" alt="image" src="https://github.com/user-attachments/assets/772d2bba-e934-4153-ad88-4c8ef72ea901" />
