### PR TITLE
Add Eternal Points to individual card pages

### DIFF
--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -321,16 +321,16 @@
                                   {% endif %}
                                 {% endfor %}
                             > Standard Card Pool</th>
+                            <a id="mwl-history" href="">(show history)</a>
                         </tr>
                         <tr>
-                            <th>
-                                <span
+                            <th
                                   {% for mwl_info in card.mwl_info %}
                                     {% if mwl_info.active %}
                                       class="legality-{{ mwl_info.legality }}"
                                     {% endif %}
-                                  {% endfor %}> Standard Ban List</span>
-                                  <a id="mwl-history" href="">(show history)</a>
+                                  {% endfor %}> Eternal Card Pool
+                                  
                             </th>
                         </tr>
                     </thead>

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -42,6 +42,31 @@
         });
     }
 
+    async function retrieveEternalPoints() {
+        // retrieves the latest Eternal points list 
+        // and then checks if the card is banned, or in any of the points fields 
+        // if not, it's worth 0 points. 
+        const formatInfo = await Promise.all(
+            fetchFullDataResponse(`${v3_api_url}/api/public/formats/eternal`)
+        );
+        // the API sometimes is out of date for active_card_pool_id 
+        const latest_points_code = formatInfo.data.attributes.restriction_ids.at(-1);
+        const [pointsData, printing] = await Promise.all( 
+            fetchFullDataResponse(`${v3_api_url}/api/public/restrictions/${latest_points_code}`),
+            fetchFullDataResponse(`${v3_api_url}/api/v3/public/printings/{{ card.code }}?include=card`),
+        );
+        const cardId = printing.data.attributes.card_id; 
+        if (pointsData.data.attributes.verdicts.banned.includes(cardId)){
+            document.getElementById("eternal-card-pool").className = "legality-banned";
+        }
+        else {
+            const pointsCost = pointsData.data.attributes.verdicts.points[cardId] || 0;
+            document.getElementById("eternal-card-pool").className = `legality-eternal-${pointsCost}-points`;
+        }
+        // remove the loading spinner after the fact
+        document.getElementById("eternal-loading").remove();
+    }
+
     async function fetchAndDisplayPrintingsPronounsAndPronunciation() {
         const [printing, card_sets] = await Promise.all(
             [
@@ -170,6 +195,7 @@
         });
     }
     fetchAndDisplayPrintingsPronounsAndPronunciation();
+    retrieveEternalPoints();
 </script>
 
 <div class="row narrative-switchable">
@@ -324,13 +350,9 @@
                             <a id="mwl-history" href="">(show history)</a>
                         </tr>
                         <tr>
-                            <th
-                                  {% for mwl_info in card.mwl_info %}
-                                    {% if mwl_info.active %}
-                                      class="legality-{{ mwl_info.legality }}"
-                                    {% endif %}
-                                  {% endfor %}> Eternal Card Pool
-                                  
+                            <th id="eternal-card-pool>
+                                <span id="eternal-loading" class="loading-icon">
+                                Eternal Card Pool
                             </th>
                         </tr>
                     </thead>

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -62,8 +62,6 @@
             const pointsCost = pointsData.data.attributes.verdicts.points[cardId] || 0;
             document.getElementById("eternal-card-pool").className = `legality-eternal-${pointsCost}-points`;
         }
-        // remove the loading spinner after the fact
-        document.getElementById("eternal-loading").remove();
     }
 
     async function fetchAndDisplayPrintingsPronounsAndPronunciation() {
@@ -360,7 +358,6 @@
                 </table>
 
                 <div id="eternal-card-pool">
-                    <span id="eternal-loading" class="loading-icon fa fa-spinner fa-spin fa-2x"></span>
                     Eternal Card Pool
                 </div>
 

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -42,24 +42,20 @@
         });
     }
 
-    async function retrieveEternalPoints() {
+    async function retrieveEternalPoints(printing) {
         // retrieves the latest Eternal points list 
         // and then checks if the card is banned, or in any of the points fields 
         // if not, it's worth 0 points. 
+        const points = printing.data.attributes.restrictions.points;
+
         const formatInfo = await fetchFullDataResponse(`${v3_api_url}/api/v3/public/formats/eternal`);
-        const latest_points_code = formatInfo.data.attributes.active_restriction_id;
-        const [pointsData, printing] = await Promise.all( 
-            [
-                fetchFullDataResponse(`${v3_api_url}/api/v3/public/restrictions/${latest_points_code}`),
-                fetchFullDataResponse(`${v3_api_url}/api/v3/public/printings/{{ card.code }}?include=card`)
-            ]
-        );
-        const cardId = printing.data.attributes.card_id; 
-        if (pointsData.data.attributes.verdicts.banned.includes(cardId)){
+        const latestPointsCode = formatInfo.data.attributes.active_restriction_id;
+        
+        if (printing.data.attributes.restrictions.banned.includes(latestPointsCode)){
             document.getElementById("eternal-card-pool").className = "legality-banned";
         }
         else {
-            const pointsCost = pointsData.data.attributes.verdicts.points[cardId] || 0;
+            const pointsCost = points[latestPointsCode] ?? 0;
             document.getElementById("eternal-card-pool").className = `legality-eternal-${pointsCost}-points`;
         }
     }
@@ -74,6 +70,8 @@
             ]
         );
 
+        // Piggyback off this fetch to update eternal points as needed
+        retrieveEternalPoints(printing);
         // Make a list of face buttons for cards with more than 1 face.
         const cardImageFlippable = document.querySelector('.card-image-flippable');
         const buttonContainer = document.querySelector('.card-image-flippable-buttons');
@@ -192,7 +190,6 @@
         });
     }
     fetchAndDisplayPrintingsPronounsAndPronunciation();
-    retrieveEternalPoints();
 </script>
 
 <div class="row narrative-switchable">
@@ -357,7 +354,7 @@
                     </tbody>
                 </table>
 
-                <div id="eternal-card-pool">
+                <div id="eternal-card-pool", class="legality-eternal-loading">
                     Eternal Card Pool
                 </div>
 

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -46,14 +46,13 @@
         // retrieves the latest Eternal points list 
         // and then checks if the card is banned, or in any of the points fields 
         // if not, it's worth 0 points. 
-        const formatInfo = await Promise.all(
-            fetchFullDataResponse(`${v3_api_url}/api/public/formats/eternal`)
-        );
-        // the API sometimes is out of date for active_card_pool_id 
-        const latest_points_code = formatInfo.data.attributes.restriction_ids.at(-1);
+        const formatInfo = await fetchFullDataResponse(`${v3_api_url}/api/v3/public/formats/eternal`);
+        const latest_points_code = formatInfo.data.attributes.active_restriction_id;
         const [pointsData, printing] = await Promise.all( 
-            fetchFullDataResponse(`${v3_api_url}/api/public/restrictions/${latest_points_code}`),
-            fetchFullDataResponse(`${v3_api_url}/api/v3/public/printings/{{ card.code }}?include=card`),
+            [
+                fetchFullDataResponse(`${v3_api_url}/api/v3/public/restrictions/${latest_points_code}`),
+                fetchFullDataResponse(`${v3_api_url}/api/v3/public/printings/{{ card.code }}?include=card`)
+            ]
         );
         const cardId = printing.data.attributes.card_id; 
         if (pointsData.data.attributes.verdicts.banned.includes(cardId)){
@@ -330,32 +329,24 @@
             </div>
 
             <div class="panel-body">
+                
+                <div class="legality-{{ card.startup_legality }}"> Startup Card Pool</div>
+
+                <div
+                    {% for mwl_info in card.mwl_info %}
+                        {% if mwl_info.active %}
+                            {% if card.standard_legality == 'available' %}
+                                class="legality-{{ mwl_info.legality }}"
+                            {% else %}
+                                class="legality-{{ card.standard_legality }}"
+                            {% endif %}
+                        {% endif %}
+                    {% endfor %}
+                > 
+                    Standard Card Pool
+                    <a id="mwl-history" href="">(show history)</a>
+                </div>
                 <table>
-                    <thead>
-                        <tr>
-                            <th class="legality-{{ card.startup_legality }}"> Startup Card Pool</th>
-                        </tr>
-                        <tr>
-                            <th
-                                {% for mwl_info in card.mwl_info %}
-                                  {% if mwl_info.active %}
-                                    {% if card.standard_legality == 'available' %}
-                                      class="legality-{{ mwl_info.legality }}"
-                                    {% else %}
-                                      class="legality-{{ card.standard_legality }}"
-                                    {% endif %}
-                                  {% endif %}
-                                {% endfor %}
-                            > Standard Card Pool</th>
-                            <a id="mwl-history" href="">(show history)</a>
-                        </tr>
-                        <tr>
-                            <th id="eternal-card-pool>
-                                <span id="eternal-loading" class="loading-icon">
-                                Eternal Card Pool
-                            </th>
-                        </tr>
-                    </thead>
                     <tbody>
                         <tr class="card-mwl-inactive" style="display:none; height: 10px;"></tr>
                         {% for mwl_info in card.mwl_info %}
@@ -367,6 +358,13 @@
                         {% endfor %}
                     </tbody>
                 </table>
+
+                <div id="eternal-card-pool">
+                    <span id="eternal-loading" class="loading-icon fa fa-spinner fa-spin fa-2x"></span>
+                    Eternal Card Pool
+                </div>
+
+                
             </div>
             <div class="panel-body">
                 <table>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1643,7 +1643,7 @@ ul.rulings-list blockquote {
   background-color: var(--nrdb-color--legal);
 }
 
-.legality-eternal-1-point:before {
+.legality-eternal-1-points:before {
   content: "1 POINT";
   background-color: var(nrdb-color--eternal-points);
 }

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -146,7 +146,7 @@
   --nrdb-color--banned: #7F4554;
   --nrdb-color--rotated: #37435E;
   --nrdb-color--restricted: #674B76;
-    --nrdb-color--eternal-points: #B85C00; 
+  --nrdb-color--eternal-points: #B85C00; 
 
   --nrdb-color--unverified: #494949;
   --nrdb-color--code: inherit;
@@ -1582,6 +1582,7 @@ ul.rulings-list blockquote {
 .legality-restricted:before,
 .legality-1-inf:before,
 .legality-3-inf:before,
+.legality-eternal-loading:before,
 .legality-eternal-0-points:before,
 .legality-eternal-1-points:before,
 .legality-eternal-2-points:before,
@@ -1643,6 +1644,11 @@ ul.rulings-list blockquote {
   background-color: var(--nrdb-color--restricted);
 }
 
+.legality-eternal-loading:before {
+  content: "LOADING";
+  background-color: var(--nrdb-color--unverified);
+}
+
 .legality-eternal-0-points:before {
   content: "0 POINTS";
   background-color: var(--nrdb-color--legal);
@@ -1662,7 +1668,6 @@ ul.rulings-list blockquote {
   content: "3 POINTS";
   background-color: var(--nrdb-color--eternal-points);
 }
-
 
 .legality-eternal-4-points:before {
   content: "4 POINTS";

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -37,6 +37,7 @@
   --nrdb-color--banned: #B66;
   --nrdb-color--rotated: #558DEC;
   --nrdb-color--restricted: #8E80FF;
+  --nrdb-color--eternal-points: orange; 
   --nrdb-color--unverified: #8F8F8F;
   --nrdb-color--code: #c7254e;
   --nrdb-color--code-bg: #f9f2f4;
@@ -145,6 +146,8 @@
   --nrdb-color--banned: #7F4554;
   --nrdb-color--rotated: #37435E;
   --nrdb-color--restricted: #674B76;
+    --nrdb-color--eternal-points: #C6B460; 
+
   --nrdb-color--unverified: #494949;
   --nrdb-color--code: inherit;
   --nrdb-color--code-bg: var(--nrdb-color--border);
@@ -1633,6 +1636,32 @@ ul.rulings-list blockquote {
 .legality-restricted:before {
   content: "RESTRICTED";
   background-color: var(--nrdb-color--restricted);
+}
+
+.legality-eternal-0-points:before {
+  content: "0 POINTS";
+  background-color: var(--nrdb-color--legal);
+}
+
+.legality-eternal-1-point:before {
+  content: "1 POINT";
+  background-color: var(nrdb-color--eternal-points);
+}
+
+.legality-eternal-2-points:before {
+  content: "2 POINTS";
+  background-color: var(nrdb-color--eternal-points);
+}
+
+.legality-eternal-3-points:before {
+  content: "3 POINTS";
+  background-color: var(nrdb-color--eternal-points);
+}
+
+
+.legality-eternal-4-points:before {
+  content: "4 POINTS";
+  background-color: var(nrdb-color--eternal-points);
 }
 
 .legality-1-inf:before {

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -37,7 +37,7 @@
   --nrdb-color--banned: #B66;
   --nrdb-color--rotated: #558DEC;
   --nrdb-color--restricted: #8E80FF;
-  --nrdb-color--eternal-points: orange; 
+  --nrdb-color--eternal-points: #B85C00; 
   --nrdb-color--unverified: #8F8F8F;
   --nrdb-color--code: #c7254e;
   --nrdb-color--code-bg: #f9f2f4;
@@ -146,7 +146,7 @@
   --nrdb-color--banned: #7F4554;
   --nrdb-color--rotated: #37435E;
   --nrdb-color--restricted: #674B76;
-    --nrdb-color--eternal-points: #C6B460; 
+    --nrdb-color--eternal-points: #B85C00; 
 
   --nrdb-color--unverified: #494949;
   --nrdb-color--code: inherit;

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1581,7 +1581,12 @@ ul.rulings-list blockquote {
 .legality-added:before,
 .legality-restricted:before,
 .legality-1-inf:before,
-.legality-3-inf:before {
+.legality-3-inf:before,
+.legality-eternal-0-points:before,
+.legality-eternal-1-points:before,
+.legality-eternal-2-points:before,
+.legality-eternal-3-points:before,
+.legality-eternal-4-points:before {
   display: inline-block;
   min-width: 7.5em;
   border-radius: 100px;
@@ -1645,23 +1650,23 @@ ul.rulings-list blockquote {
 
 .legality-eternal-1-points:before {
   content: "1 POINT";
-  background-color: var(nrdb-color--eternal-points);
+  background-color: var(--nrdb-color--eternal-points);
 }
 
 .legality-eternal-2-points:before {
   content: "2 POINTS";
-  background-color: var(nrdb-color--eternal-points);
+  background-color: var(--nrdb-color--eternal-points);
 }
 
 .legality-eternal-3-points:before {
   content: "3 POINTS";
-  background-color: var(nrdb-color--eternal-points);
+  background-color: var(--nrdb-color--eternal-points);
 }
 
 
 .legality-eternal-4-points:before {
   content: "4 POINTS";
-  background-color: var(nrdb-color--eternal-points);
+  background-color: var(--nrdb-color--eternal-points);
 }
 
 .legality-1-inf:before {


### PR DESCRIPTION
Right now we have Standard Card Pool and Standard Ban List views. However the only case where those would differ is when the card is still banned but rotated (because I forgot to remove it from the ban list). Consolidating those together into "Standard Card Pool" while retaining the historical view should avoid any loss of information. 

In the place of "Standard Ban List" there's a new entry that tracks Eternal Points costs. This hits the new API, finds the points value, and updates the cell. 

Right now it's a bit sluggish because we need a new API call so there's clear client side updating for the eternal points, but otherwise I think this is good to PR?


<img width="2358" height="1194" alt="image" src="https://github.com/user-attachments/assets/fa319f6c-2462-437b-b515-accc605d7af4" />

 versus Watch the World Burn which is still banned 
 
 
<img width="2356" height="1174" alt="image" src="https://github.com/user-attachments/assets/f8cd1213-0463-40aa-879c-95a9c3e3a65f" />

Also I partially refactored the card pools section to not be so heavily based on a table. There's client side JS in zoom.js that needs to be updated before I can pull all of the table based layout from this section. 
