### PR TITLE
Use xlarge webp for zoom view and PNP, add PNP progress bar

### DIFF
--- a/app/Resources/views/Builder/printandplay.html.twig
+++ b/app/Resources/views/Builder/printandplay.html.twig
@@ -97,6 +97,14 @@ var CardDB, CardNames;
       <button id="btn-print" class="btn btn-success" disabled onclick="do_print()" style="margin-bottom:2em">Print</button>
       <button id="btn-clear" class="btn btn-danger" onclick="do_clear()" style="margin-left:0.8em;margin-bottom:2em">Clear</button>
     </div>
+
+    <div class="row">
+      <div id="print-progress" class="progress" style="width: 93%; display:none;">
+        <div id="print-progress-bar" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%;">
+        </div>
+      </div>
+    </div>
+
     <div class="row" id="preview-container"></div>
   </div>
 </div> <!-- .row -->

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -78,7 +78,12 @@
                 button.innerHTML = buttonText;
                 button.dataset.face = i;
                 // Use the main image for the first button and the face image for i - 1 (because we are combining the front face with the faces array)
-                let buttonImg = i == 0 ? printing.data.attributes.images.nrdb_classic.large : printing.data.attributes.faces[i-1].images.nrdb_classic.large;
+                let buttonImg = null;
+                if(printing.data.attributes.images.nrdb_classic.xlarge) {
+                  buttonImg = i == 0 ? printing.data.attributes.images.nrdb_classic.xlarge : printing.data.attributes.faces[i-1].images.nrdb_classic.xlarge;
+                } else {
+                  buttonImg = i == 0 ? printing.data.attributes.images.nrdb_classic.large : printing.data.attributes.faces[i-1].images.nrdb_classic.large;
+                }
                 button.dataset.img = buttonImg;
 
                 button.addEventListener("click", function(e) {
@@ -178,7 +183,7 @@
             {% if card.imageUrl %}
                 <div class="card-image-flippable">
                     <div class="card-image card-image-flippable__front">
-                        <img id="current_card_img" data-src="{{ card_image_url }}{{ asset(card.large_image_path) }}" alt="{{ card.title }}" class="img-responsive lazyload card-image" style="margin:auto">
+                        <img id="current_card_img" data-src="{{ card_image_url }}{{ asset(card.largest_image_path) }}" alt="{{ card.title }}" class="img-responsive lazyload card-image" style="margin:auto">
                     </div>
                     <div class="card-image card-image-flippable__back">
                         <img id="alternate_card_img" src="" class="img-responsive">

--- a/app/Resources/views/Search/display-zoom.html.twig
+++ b/app/Resources/views/Search/display-zoom.html.twig
@@ -79,7 +79,7 @@
                 button.dataset.face = i;
                 // Use the main image for the first button and the face image for i - 1 (because we are combining the front face with the faces array)
                 let buttonImg = null;
-                if(printing.data.attributes.images.nrdb_classic.xlarge) {
+                if (printing.data.attributes.images.nrdb_classic.xlarge) {
                   buttonImg = i == 0 ? printing.data.attributes.images.nrdb_classic.xlarge : printing.data.attributes.faces[i-1].images.nrdb_classic.xlarge;
                 } else {
                   buttonImg = i == 0 ? printing.data.attributes.images.nrdb_classic.large : printing.data.attributes.faces[i-1].images.nrdb_classic.large;

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -1048,6 +1048,34 @@ class Card implements NormalizableInterface, TimestampableInterface
     }
 
     /**
+     * @return string|null
+     */
+    public function getXLargeImagePath()
+    {
+        if($this->pack->getDateRelease() > new \DateTime('2019-03-01')  // New than Ashes
+           && $this->pack->getCode() != 'mor'
+           && $this->pack->getCode() != 'su21'
+           && $this->pack->getCode() != 'sm') {
+            return '/xlarge/' . $this->code . '.webp';
+        } else {
+            return null;
+        };
+    }
+
+    /**
+     * @return string
+     */
+    public function getLargestImagePath() {
+        $xl = $this->getXLargeImagePath();
+        if($xl) {
+            return $xl;
+        } else {
+            return $this->getLargeImagePath();
+        }
+    }
+
+
+    /**
      * @return null|string
      */
     public function getImageUrl()

--- a/src/AppBundle/Entity/Card.php
+++ b/src/AppBundle/Entity/Card.php
@@ -1052,7 +1052,7 @@ class Card implements NormalizableInterface, TimestampableInterface
      */
     public function getXLargeImagePath()
     {
-        if($this->pack->getDateRelease() > new \DateTime('2019-03-01')  // New than Ashes
+        if ($this->pack->getDateRelease() > new \DateTime('2019-03-01')  // Newer than Ashes
            && $this->pack->getCode() != 'mor'
            && $this->pack->getCode() != 'su21'
            && $this->pack->getCode() != 'sm') {
@@ -1067,7 +1067,7 @@ class Card implements NormalizableInterface, TimestampableInterface
      */
     public function getLargestImagePath() {
         $xl = $this->getXLargeImagePath();
-        if($xl) {
+        if ($xl) {
             return $xl;
         } else {
             return $this->getLargeImagePath();

--- a/src/AppBundle/Service/CardsData.php
+++ b/src/AppBundle/Service/CardsData.php
@@ -869,6 +869,8 @@ class CardsData
             "small_image_path"  => $card->getSmallImagePath(),
             "medium_image_path" => $card->getMediumImagePath(),
             "large_image_path"  => $card->getLargeImagePath(),
+            "xlarge_image_path"  => $card->getXLargeImagePath(),
+            "largest_image_path"  => $card->getLargestImagePath(),
         ];
 
         // setting the card cost to X if the cost is null and the card is not of a costless type

--- a/web/js/nrdb.data.js
+++ b/web/js/nrdb.data.js
@@ -191,7 +191,7 @@
         });
         _.each(data.cards.find(), function (card) {
             /* Update image_url to use xlarge if available */
-            if(data.filter_for_nsg(card)) {
+            if (data.filter_for_nsg(card)) {
               data.cards.updateById(card.code, {
                 imageUrl: `https://card-images.netrunnerdb.com/v2/xlarge/${card.code}.webp`,
               });

--- a/web/js/nrdb.data.js
+++ b/web/js/nrdb.data.js
@@ -189,6 +189,14 @@
                 pack: data.packs.findById(card.pack_code)
             });
         });
+        _.each(data.cards.find(), function (card) {
+            /* Update image_url to use xlarge if available */
+            if(data.filter_for_nsg(card)) {
+              data.cards.updateById(card.code, {
+                imageUrl: `https://card-images.netrunnerdb.com/v2/xlarge/${card.code}.webp`,
+              });
+            }
+        });
 
         data.isLoaded = true;
 
@@ -213,5 +221,12 @@
     $(function () {
         data.load();
     });
+
+    data.filter_for_nsg = function filter_for_nsg(card) {
+      return new Date(card.pack.date_release) >= new Date('2019-03-18')  // Downfall
+        && card.pack.name != "Magnum Opus Reprint"
+        && card.pack.name != "System Update 2021"
+        && card.pack.name != "Salvaged Memories"
+    }
 
 })(NRDB.data = {}, jQuery);

--- a/web/js/pnp.js
+++ b/web/js/pnp.js
@@ -16,10 +16,10 @@
  * - Lia
  * */
 var multi_side_cards = {
-  "26066" : ["https://card-images.netrunnerdb.com/v2/large/26066-0.jpg"], // Hoshiko
-  "26120" : ["https://card-images.netrunnerdb.com/v2/large/26120-0.jpg"], // Earth Station
-  "35023" : ["https://card-images.netrunnerdb.com/v2/large/35023-0.jpg"], // Dewi
-  "35057" : ["https://card-images.netrunnerdb.com/v2/large/35057-0.jpg"], // Nebula
+  "26066" : ["https://card-images.netrunnerdb.com/v2/xlarge/26066-0.webp"], // Hoshiko
+  "26120" : ["https://card-images.netrunnerdb.com/v2/xlarge/26120-0.webp"], // Earth Station
+  "35023" : ["https://card-images.netrunnerdb.com/v2/xlarge/35023-0.webp"], // Dewi
+  "35057" : ["https://card-images.netrunnerdb.com/v2/xlarge/35057-0.webp"], // Nebula
 };
 
 Promise.all([NRDB.data.promise, NRDB.ui.promise]).then( () => {
@@ -260,10 +260,7 @@ var imported_cards = {};
 
 function filter_for_nsg(cards) {
   return cards.filter(card => {
-    return new Date(card.pack.date_release) >= new Date('2019-03-18')  // Downfall
-        && card.pack.name != "Magnum Opus Reprint"
-        && card.pack.name != "System Update 2021"
-        && card.pack.name != "Salvaged Memories"
+    return NRDB.data.filter_for_nsg(card);
   });
 }
 


### PR DESCRIPTION
The images, they're crispy.

This depends on https://github.com/NetrunnerDB/netrunnerdb-api-server/pull/411, but is still able to appropriately fallback to large jpgs without it.

An unintended consequence of using xlarge webps is that a fresh PNP takes ~17 seconds and that's honestly way too long. I don't really know how I could speed this up but I can at least make this more palatable by adding a progress bar. ~This might involve moving the pdf generation part to a web worker. I'd like to do this before all this goes live if possible.~

I've also refactored the print code to not be so UI blocking and added a progress bar. Print is still slow but it's honestly pretty palatable with a nice progress bar.
<img width="767" height="560" alt="image" src="https://github.com/user-attachments/assets/5fcf4a37-7d7f-4e0b-96a4-3a1bcf15da4b" />
