### PR TITLE
[PNP] Allow enabling/disabling sets

### DIFF
--- a/app/Resources/views/Builder/printandplay.html.twig
+++ b/app/Resources/views/Builder/printandplay.html.twig
@@ -25,10 +25,10 @@ var CardDB, CardNames;
   </button>
 </div>
 <div class="row">
-  <div class="col-md-5">
+  <div class="col-md-4">
     <form role="form">
       <div class="form-group">
-        <textarea placeholder="Paste deck here and click import" class="form-control" id="pnp-text-area" name="content" rows="10">
+        <textarea placeholder="Paste deck here and click import" class="form-control" id="pnp-text-area" name="content" rows="15">
         {%- if decklist is not empty -%}
            {{- decklist |trim -}}
         {%- endif -%}
@@ -46,7 +46,7 @@ var CardDB, CardNames;
     </form>
   </div>
 
-  <div class="col-md-4">
+  <div class="col-md-2">
     <form id="settings">
       <div class="form-group">
         <label>
@@ -79,10 +79,16 @@ var CardDB, CardNames;
       </div>
     </form>
   </div>
+  <div class="col-md-4">
+    <div class="panel panel-default">
+      <div class="panel-heading">Collection</div>
+      <div class="panel-body" id="pack_code" style="overflow-y:scroll;max-height:17em"></div>
+    </div>
+  </div>
 </div> <!-- .row -->
 
 <div class="row">
-  <div class="col-md-5">
+  <div class="col-md-4">
 
     <input type="text" placeholder="Card Search" class="form-control" name="q" id="pnp-card-search">
 
@@ -92,7 +98,7 @@ var CardDB, CardNames;
     </div>
     <input type="hidden" name="content">
   </div>
-  <div class="col-md-7">
+  <div class="col-md-8">
     <div class="row">
       <button id="btn-print" class="btn btn-success" disabled onclick="do_print()" style="margin-bottom:2em">Print</button>
       <button id="btn-clear" class="btn btn-danger" onclick="do_clear()" style="margin-left:0.8em;margin-bottom:2em">Clear</button>

--- a/web/js/nrdb.data.js
+++ b/web/js/nrdb.data.js
@@ -191,7 +191,7 @@
         });
         _.each(data.cards.find(), function (card) {
             /* Update image_url to use xlarge if available */
-            if (data.filter_for_nsg(card)) {
+            if (data.filter_card_for_nsg(card)) {
               data.cards.updateById(card.code, {
                 imageUrl: `https://card-images.netrunnerdb.com/v2/xlarge/${card.code}.webp`,
               });
@@ -222,11 +222,19 @@
         data.load();
     });
 
-    data.filter_for_nsg = function filter_for_nsg(card) {
-      return new Date(card.pack.date_release) >= new Date('2019-03-18')  // Downfall
-        && card.pack.name != "Magnum Opus Reprint"
-        && card.pack.name != "System Update 2021"
-        && card.pack.name != "Salvaged Memories"
+    data.filter_cycle_for_nsg = function filter_cycle_for_nsg(cycle) {
+      return cycle.position >= 26  // Ashes
+        && cycle.name != "Magnum Opus Reprint"
+        && cycle.name != "System Update 2021"
+        && cycle.name != "Salvaged Memories"
+    }
+
+    data.filter_pack_for_nsg = function filter_pack_for_nsg(pack) {
+      return data.filter_cycle_for_nsg(pack.cycle);
+    }
+
+    data.filter_card_for_nsg = function filter_card_for_nsg(card) {
+      return data.filter_cycle_for_nsg(card.pack.cycle);
     }
 
 })(NRDB.data = {}, jQuery);


### PR DESCRIPTION
The idea behind this feature is if you already own a physical set, you may not ever need to print anything from that set. You can uncheck the sets that you already have and the cards will be automatically filtered out from PNP. This selection is also persistent. 

Also, hard to notice but the left card list and importer textbox is narrowed slightly to give more room on the right side for the collection panel.

In the future I might extend this to allow you to select/deselect individual cards (like say you own system gateway but need to print extra spins/sure gamble every time). Might be too much worth for what it's worth though.

<img width="1199" height="891" alt="image" src="https://github.com/user-attachments/assets/41fc8892-a658-42ec-a6d3-34a3ad4d3060" />

