### PR TITLE
Fix equality checks in the judge code.

### DIFF
--- a/src/AppBundle/Command/LegalityApplyMwlCommand.php
+++ b/src/AppBundle/Command/LegalityApplyMwlCommand.php
@@ -84,7 +84,7 @@ class LegalityApplyMwlCommand extends ContainerAwareCommand
                 continue;
             }
             $progress = new ProgressBar($output, $count);
-            $batchSize = 100;
+            $batchSize = 1000;
             $progress->setRedrawFrequency($batchSize);
             $progress->start();
 

--- a/src/AppBundle/Service/Judge.php
+++ b/src/AppBundle/Service/Judge.php
@@ -254,7 +254,7 @@ class Judge
                 $problem = 'copies';
             }
 
-            if ($card->getSide() !== $identity->getSide()) {
+            if ($card->getSide()->getCode() !== $identity->getSide()->getCode()) {
                 $problem = 'side';
             }
 
@@ -264,7 +264,7 @@ class Judge
 
             if ($card->getType()->getCode() === "agenda") {
                 if ($card->getFaction()->getCode() !== "neutral-corp"
-                    && $card->getFaction() !== $identity->getFaction()
+                    && $card->getFaction()->getCode() !== $identity->getFaction()->getCode()
                     && $identity->getFaction()->getCode() !== "neutral-corp"
                 ) {
                     $problem = 'agendas';


### PR DESCRIPTION
I was able to reproduce this by locally making decks that should have been legal and running this through the code locally and inspecting the problems reported by the judge.  

This also ups the batch size for the command that applies legality.