### PR TITLE
Fix the handling for agenda influence in the card importer.

### DIFF
--- a/src/AppBundle/Command/ImportStdCommand.php
+++ b/src/AppBundle/Command/ImportStdCommand.php
@@ -506,8 +506,13 @@ class ImportStdCommand extends ContainerAwareCommand
             }
         }
 
-        // Special case faction cost for agenda and identity cards which will always have null values returned as 0.
-        if ($entityName == 'AppBundle\Entity\Card' && $fieldName == 'factionCost' && ($entity->getType()->getCode() == 'identity' || $entity->getType()->getCode() == 'agenda')) {
+        // Special case faction cost for identity cards which will always have null values returned as 0.
+        if ($entityName == 'AppBundle\Entity\Card' && $fieldName == 'factionCost' && $entity->getType()->getCode() == 'identity') {
+            return;
+        }
+
+        // Skip this for agendas without a faction cost in $newValue.
+        if ($entityName == 'AppBundle\Entity\Card' && $fieldName == 'factionCost' && $entity->getType()->getCode() == 'agenda' && ($newJsonValue === 0 || $newJsonValue === null)) {
             return;
         }
 


### PR DESCRIPTION
This fixes a clumsy "fix" from https://github.com/Null-Signal-Games/netrunnerdb/commit/6495d209fd4c7c1808db0110cd8faec2c9e1d859

NRDB Classic handles faction cost and ids and agendas a bit oddly, with a NULL instead of a 0 where there is no faction cost set.  The previous commit just *never set this value*.  This change sets it only when the new value is non null and non-zero.