### PR TITLE
PNP: Melies U and non-owner deck view PNP button

### DIFF
--- a/app/Resources/views/Builder/deckview.html.twig
+++ b/app/Resources/views/Builder/deckview.html.twig
@@ -44,12 +44,12 @@ var Identity = null,
 
 <!-- Buttons -->
 <div class="btn-actions text-center">
+  <div class="btn-group" role="group" style="margin-bottom:5px">
+      <button type="button" id="btn-pnp" class="btn btn-pnp btn-sm"><span class="glyphicon glyphicon-print"></span> Print &amp; Play</button>
+  </div>
   {% if deck.is_owner %}
   <div class="btn-group" role="group" style="margin-bottom:5px">
     <button type="button" id="btn-print" class="btn btn-info btn-sm"><span class="glyphicon glyphicon-print"></span> Print</button>
-  </div>
-  <div class="btn-group" role="group" style="margin-bottom:5px">
-      <button type="button" id="btn-pnp" class="btn btn-pnp btn-sm"><span class="glyphicon glyphicon-print"></span> Print &amp; Play</button>
   </div>
   <div class="btn-group" role="group" style="margin-bottom:5px">
     <button type="button" id="btn-edit" class="btn btn-primary btn-sm"><span class="glyphicon glyphicon-pencil"></span> Edit</button>

--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -1328,8 +1328,6 @@ class BuilderController extends Controller
      * @param Deck $deck
      * @return Response
      *
-     * @IsGranted("IS_AUTHENTICATED_REMEMBERED")
-     *
      * @ParamConverter("deck", class="AppBundle:Deck", options={"mapping": {"deck_uuid": "uuid"}})
      */
     public function printAndPlayAction(?Deck $deck = null)
@@ -1339,13 +1337,15 @@ class BuilderController extends Controller
         $response->setMaxAge($this->getParameter('long_cache'));
 
         $decklist = "";
-        if($deck) {
+        if ($deck &&
+            ($this->getUser()->getId() == $deck->getUser()->getId() ||
+             $deck->getUser()->getShareDecks())) {
             foreach($deck->getSlots() as $slot) {
                 $decklist .= strval($slot->getQuantity()) . " " . $slot->getCard()->getTitle() . PHP_EOL;
             }
         }
-        return $this->render(
 
+        return $this->render(
             '/Builder/printandplay.html.twig',
             [
                 'pagetitle' => "Print and Play",

--- a/web/js/pnp.js
+++ b/web/js/pnp.js
@@ -20,6 +20,11 @@ var multi_side_cards = {
   "26120" : ["https://card-images.netrunnerdb.com/v2/xlarge/26120-0.webp"], // Earth Station
   "35023" : ["https://card-images.netrunnerdb.com/v2/xlarge/35023-0.webp"], // Dewi
   "35057" : ["https://card-images.netrunnerdb.com/v2/xlarge/35057-0.webp"], // Nebula
+  "36036" : ["https://card-images.netrunnerdb.com/v2/xlarge/36036.webp",  // Melies U prints 3 front and 3 back
+             "https://card-images.netrunnerdb.com/v2/xlarge/36036.webp",
+             "https://card-images.netrunnerdb.com/v2/xlarge/36036-0.webp",
+             "https://card-images.netrunnerdb.com/v2/xlarge/36036-1.webp",
+             "https://card-images.netrunnerdb.com/v2/xlarge/36036-2.webp"],
 };
 
 var basic_action_cards = [


### PR DESCRIPTION
### Melies U
Hard-coded because I think it's not worth making expensive(?) api call for every card added to PNP. Hopefully we only have to continue doing this until V2.

<img width="1192" height="782" alt="image" src="https://github.com/user-attachments/assets/34b8f172-ca12-44ce-a041-892c28b6c147" />

### Non-owner deck view PNP button
I would appreciate a review on the permission side of things. The PNP deck endpoint now only checks if the user is deck owner or deck owner has share deck enabled (previously required user to owner to use the PNP deck endpoint).

<img width="720" height="216" alt="image" src="https://github.com/user-attachments/assets/548d52f3-81cd-4431-bc95-053b26ed3f0b" />
