### PR TITLE
Add new jnet deck meta-data when exporting deck

### DIFF
--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -1144,6 +1144,14 @@ function build_jintekinet(deck) {
     var deck = process_deck_by_type(deck || SelectedDeck);
     var lines = [];
 
+    lines.push(";; identity: " + Identity.title);
+    lines.push(";; title: " + SelectedDeck.name);
+    var deckUrl = (typeof Decklist != "undefined" && Decklist != null)
+        ? location.origin + Routing.generate('decklist_view', {decklist_uuid: Decklist.uuid})
+        : location.origin + Routing.generate('deck_view', {deck_uuid: SelectedDeck.uuid});
+    lines.push(";; notes: " + deckUrl);
+    lines.push("");
+
     $('#deck-content > div > div > div').each(function (i, line) {
         var num = $(line).contents().filter(function () {
             return this.nodeType == 3;

--- a/web/js/nrdb.js
+++ b/web/js/nrdb.js
@@ -1144,7 +1144,7 @@ function build_jintekinet(deck) {
     var deck = process_deck_by_type(deck || SelectedDeck);
     var lines = [];
 
-    lines.push(";; identity: " + Identity.title);
+    lines.push(";; identity-code: " + Identity.code);
     lines.push(";; title: " + SelectedDeck.name);
     var deckUrl = (typeof Decklist != "undefined" && Decklist != null)
         ? location.origin + Routing.generate('decklist_view', {decklist_uuid: Decklist.uuid})


### PR DESCRIPTION
JNet will have support for new meta-data when copying in a deck list that allows setting the identity and deck name. Added those fields to the jnet export function.

Jnet PR here: https://github.com/mtgred/netrunner/pull/8611