### PR TITLE
Simplify Docker setup

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -22,6 +22,7 @@ nrdb-dev-env.
 cd ..
 git checkout https://github.com/netrunnerdb/netrunnerdb
 git checkout https://github.com/netrunnerdb/netrunner-cards-json
+cp -r netrunnerdb/docker nrdb-dev-env
 cd nrdb-dev-env
 ```
 
@@ -58,3 +59,11 @@ To update the card data, run:
 ```
 
 while your docker image is running.
+
+To reset your local setup, run:
+
+```sh
+docker-compose down -v
+rm netrunner-cards-json
+rm netrunnerdb
+```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,29 +11,16 @@ services:
     links:
       - nrdb-dev-db
     volumes:
-      # These folders and files will have links or copies made of them.
-      - ./netrunnerdb/bin:/var/www/html/nrdb-bin
-      - ./netrunnerdb/web:/var/www/html/nrdb-web
-      - ./dev-parameters.yml:/var/www/html/nrdb-app-config-parameters.yml
-      # Make a copy of app/config/ so we can link to the files in there from
-      # /var/www/html/nrdb/app/config to avoid a parameters.yml file being
-      # written to our repo there.
-      - ./netrunnerdb/app/config:/var/www/html/nrdb-app-config
       # Link up the nrdb source code and card database.
       - ./netrunnerdb:/var/www/html/nrdb
       - ./netrunner-cards-json:/var/www/html/nrdb/cards
       # redirect everything to app_dev.php rather than app.php
       - ./.htaccess:/var/www/html/nrdb/web/.htaccess
-      # Make sure data created by the running application isn't written
-      # to the git repo.
-      - appdata_appcfg:/var/www/html/nrdb/app/config
-      - appdata_bin:/var/www/html/nrdb/bin
-      - appdata_var:/var/www/html/nrdb/var
-      - appdata_web:/var/www/html/nrdb/web
-      - appdata_vendor:/var/www/html/nrdb/vendor
       # overwrite default app_dev.php with one that has the "does this
       # look like a dev setup?" security check commented out.
       - ./app_dev.php:/var/www/html/nrdb/web/app_dev.php
+      # define our app/config/parameters.yml with dev settings
+      - ./dev-parameters.yml:/var/www/html/nrdb/app/config/parameters.yml
 
   nrdb-dev-db:
     container_name: nrdb-dev-db
@@ -48,10 +35,4 @@ services:
       MYSQL_PASSWORD: passwd
 
 volumes:
-  appdata_appcfg:
-  appdata_bin:
-  appdata_bundles:
-  appdata_var:
-  appdata_vendor:
-  appdata_web:
   dbdata:

--- a/docker/docker-first-run.sh
+++ b/docker/docker-first-run.sh
@@ -1,42 +1,10 @@
 #!/bin/bash
 
-CHOWN="chown -R www-data:www-data"
+echo "Installing vendors ..."
+docker exec -it -u www-data nrdb-dev bash -c "composer install"
 
-# Set up permissions and copy/link files on the volumes.
-echo "Preparing /var/www/html/nrdb/app/config/"
-for FILE in $(ls netrunnerdb/app/config/)
-do
-  BASE_FILE=$(basename ${FILE})
-  docker exec -it nrdb-dev bash -c "if [ ! -L "/var/www/html/nrdb/app/config/${BASE_FILE}" ]; then ln -s /var/www/html/nrdb-app-config/${BASE_FILE} /var/www/html/nrdb/app/config/${BASE_FILE}; fi"
-done
-docker exec -it nrdb-dev bash -c "${CHOWN} /var/www/html/nrdb/app/config"
-
-# Link up files from web, minus bundles and app_dev.php
-echo "Preparing /var/www/html/nrdb/web/"
-for FILE in $(ls netrunnerdb/web/ | grep -v bundles | grep -v app_dev.php | grep -v config.php)
-do
-  BASE_FILE=$(basename ${FILE})
-  docker exec -it nrdb-dev bash -c "if [ ! -L "/var/www/html/nrdb/web/${BASE_FILE}" ]; then ln -s /var/www/html/nrdb-web/${BASE_FILE} /var/www/html/nrdb/web/${BASE_FILE}; fi"
-done
-
-docker exec -it nrdb-dev bash -c "${CHOWN} /var/www/html/nrdb/web"
-docker exec -it nrdb-dev bash -c "if [ ! -d /var/www/html/nrdb/web/bundles ]; then mkdir /var/www/html/nrdb/web/bundles; fi"
-docker exec -it nrdb-dev bash -c "${CHOWN} /var/www/html/nrdb/web/bundles"
-docker exec -it nrdb-dev bash -c " ln -s /var/www/html/nrdb/vendor /var/www/html/vendor"
-
-docker exec -it nrdb-dev bash -c "cp /var/www/html/nrdb-bin/* /var/www/html/nrdb/bin/"
-docker exec -it nrdb-dev bash -c "${CHOWN} /var/www/html/nrdb/bin"
-docker exec -it nrdb-dev bash -c "${CHOWN} /var/www/html/nrdb/var"
-docker exec -it nrdb-dev bash -c "${CHOWN} /var/www/html/nrdb/vendor"
-
-# Run composer install as www-data instead of root.
-docker exec -it nrdb-dev bash -c "cp /var/www/html/nrdb-app-config-parameters.yml /var/www/html/nrdb/app/config/parameters.yml && chown www-data:www-data /var/www/html/nrdb/app/config/parameters.yml"
-docker exec -it nrdb-dev bash -c "su -s /bin/bash www-data -c 'composer install'"
-
-echo "Initializing the database and importing the card data."
-docker exec -it nrdb-dev bash -c "php bin/console doctrine:schema:update --force; php bin/console app:import:std -f cards"
-
-docker exec -it nrdb-dev bash -c "${CHOWN} /var/www/html/nrdb/var"
+echo "Initializing the database and importing the card data ..."
+docker exec -it -u www-data nrdb-dev bash -c "php bin/console doctrine:schema:update --force; php bin/console app:import:std -f cards"
 
 echo "TODO: import card images"
 

--- a/docker/local-bash.sh
+++ b/docker/local-bash.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker exec -it nrdb-dev bash
+docker exec -it -u www-data nrdb-dev bash

--- a/docker/prepare-and-build.sh
+++ b/docker/prepare-and-build.sh
@@ -45,6 +45,7 @@ else
   ln -s "${CARDS_PATH}" netrunner-cards-json
 fi
 
+echo "Building docker images ..."
 if command -v docker compose >/dev/null 2>&1
 then
   docker compose build


### PR DESCRIPTION
Hello folks. I wanted to set up a local nrdb and found your cool Docker files. A few things in the docker-compose.yaml file surprised me and I tried to understand it. I think I found a simpler setup, let me know what you think. It works for me.

- removed the named volumes on /vendor and /var which are in .gitignore anyway
- removed the named volumes on /bin and /web because there's no reason they would be changed unexpectedly. The data in /web is already ignored by .gitignore.
- removed the named volumes on /app/config because I created a mount volume on /app/config/parameters.yml instead of copying files around

Consequently, I simplified `docker/docker-first-run.sh` too because no files need to be copied.

Benefits of this MR:

- Faster setup
- Easier to understand and maintain
- The vendors installed by "composer install" in vendor/ are accessible outside the container, so available to the IDE
- The logs files in var/log/ are accessible outside the container, should you need them
