### PR TITLE
Separate influence by quantity instead of always 5 pips

### DIFF
--- a/src/AppBundle/Controller/BuilderController.php
+++ b/src/AppBundle/Controller/BuilderController.php
@@ -503,7 +503,7 @@ class BuilderController extends Controller
                     }
 
                     for ($i = 0; $i < $slot['influence']; $i++) {
-                        if ($i % 5 == 0) {
+                        if ($i % $slot['qty'] == 0) {
                             $inf .= " ";
                         }
                         $inf .= "•";

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -745,7 +745,7 @@ class SocialController extends Controller
                     }
 
                     for ($i = 0; $i < $slot['influence']; $i++) {
-                        if ($i % 5 == 0) {
+                        if ($i % $slot['qty'] == 0) {
                             $inf .= " ";
                         }
                         $inf .= "•";


### PR DESCRIPTION
I expect this has the potential be contentious, but I would find it much easier to see at a glance how much influence is being spent and how much could be saved by cutting a card, for example, from "•• •• ••" or "••• •••" than "••••• •" as would currently be displayed. I don't do PHP, but I've done my best to suggest a change.