### PR TITLE
Add decklist social API endpoints

### DIFF
--- a/src/AppBundle/Controller/PublicApi20Controller.php
+++ b/src/AppBundle/Controller/PublicApi20Controller.php
@@ -124,7 +124,7 @@ class PublicApi20Controller extends AbstractFOSRestController
       return $response;
     }
 
-    private function prepareResponse(array $entities, Request $request, array $additionalTopLevelProperties = [])
+    private function prepareResponse(array $entities, Request $request, array $additionalTopLevelProperties = [], ?\DateTime $dateUpdateFloor = null)
     {
       $response = new JsonResponse();
       $response->headers->set('Access-Control-Allow-Origin', '*');
@@ -139,7 +139,7 @@ class PublicApi20Controller extends AbstractFOSRestController
         } else {
           return $carry;
         }
-      });
+      }, $dateUpdateFloor);
 
       $response->setLastModified($dateUpdate);
       if ($response->isNotModified($request)) {
@@ -463,6 +463,66 @@ class PublicApi20Controller extends AbstractFOSRestController
         $data = $qb->getQuery()->execute();
 
         return $this->prepareResponse($data, $request);
+    }
+
+    /**
+     * Get all comments for a decklist by id
+     *
+     * @ApiDoc(
+     *  section="Decklist",
+     *  resource=true,
+     *  description="Get all comments for a published decklist",
+     *  parameters={
+     *  },
+     * )
+     */
+    public function commentsByDecklistAction(int $decklist_id, Request $request)
+    {
+        $decklist = $this->entityManager->getRepository('AppBundle:Decklist')->findOneBy(['id' => $decklist_id]);
+        if (!$decklist) {
+            return $this->prepareFailedResponse("Decklist not found");
+        }
+        return $this->commentsResponse($decklist, $request);
+    }
+
+    /**
+     * Get all comments for a decklist by UUID
+     *
+     * @ApiDoc(
+     *  section="Decklist",
+     *  resource=true,
+     *  description="Get all comments for a published decklist",
+     *  parameters={
+     *  },
+     * )
+     */
+    public function commentsByDecklistUuidAction(string $decklist_uuid, Request $request)
+    {
+        $decklist = $this->entityManager->getRepository('AppBundle:Decklist')->findOneBy(['uuid' => $decklist_uuid]);
+        if (!$decklist) {
+            return $this->prepareFailedResponse("Decklist not found");
+        }
+        return $this->commentsResponse($decklist, $request);
+    }
+
+    private function commentsResponse(Decklist $decklist, Request $request)
+    {
+        // Only expose comments for decklists the public decklist page would show
+        // (published, restored, or trashed); deleted decklists are treated as not found.
+        if (!in_array($decklist->getModerationStatus(), [
+            Decklist::MODERATION_PUBLISHED,
+            Decklist::MODERATION_RESTORED,
+            Decklist::MODERATION_TRASHED,
+        ], true)) {
+            return $this->prepareFailedResponse("Decklist not found");
+        }
+
+        $comments = $this->entityManager->getRepository('AppBundle:Comment')->findBy(
+            ['decklist' => $decklist],
+            ['dateCreation' => 'ASC']
+        );
+
+        return $this->prepareResponse($comments, $request, [], $decklist->getDateUpdate());
     }
 
     /**

--- a/src/AppBundle/Controller/SocialController.php
+++ b/src/AppBundle/Controller/SocialController.php
@@ -624,6 +624,7 @@ class SocialController extends Controller
         }
 
         $comment->setHidden((boolean) $hidden);
+        $comment->getDecklist()->setDateUpdate(new \DateTime());
         $entityManager->flush();
 
         return new JsonResponse(true);

--- a/src/AppBundle/Entity/Comment.php
+++ b/src/AppBundle/Entity/Comment.php
@@ -2,10 +2,13 @@
 
 namespace AppBundle\Entity;
 
+use AppBundle\Behavior\Entity\NormalizableInterface;
+use AppBundle\Behavior\Entity\TimestampableInterface;
+
 /**
  * Comment
  */
-class Comment
+class Comment implements NormalizableInterface, TimestampableInterface
 {
     /**
      * @var integer
@@ -138,5 +141,24 @@ class Comment
         $this->decklist = $decklist;
 
         return $this;
+    }
+
+    public function normalize()
+    {
+        return [
+            'id'            => $this->id,
+            'text'          => $this->text,
+            'hidden'        => $this->hidden,
+            'date_creation' => $this->dateCreation->format('c'),
+            'user_id'       => $this->author->getId(),
+            'user_name'     => $this->author->getUsername(),
+            'decklist_id'   => $this->decklist->getId(),
+            'decklist_uuid' => $this->decklist->getUuid(),
+        ];
+    }
+
+    public function getDateUpdate()
+    {
+        return $this->dateCreation;
     }
 }

--- a/src/AppBundle/Entity/Decklist.php
+++ b/src/AppBundle/Entity/Decklist.php
@@ -222,6 +222,9 @@ class Decklist implements NormalizableInterface, TimestampableInterface
             'tournament_badge' => $this->tournament ? true : false,
             'cards'            => $cards,
             'mwl_code'         => $this->mwl ? $this->mwl->getCode() : null,
+            'votes_count'      => $this->nbvotes,
+            'favorites_count'  => $this->nbfavorites,
+            'comments_count'   => $this->nbcomments,
         ];
     }
 

--- a/src/AppBundle/EventListener/DecklistListener.php
+++ b/src/AppBundle/EventListener/DecklistListener.php
@@ -28,6 +28,10 @@ class DecklistListener
         return;
       }
       $this->cache->deleteItem('public-api-decklist-' . $entity->getId());
+
+      if ($entity->getUuid()) {
+        $this->cache->deleteItem('public-api-decklist-' . $entity->getUuid());
+      }
     }
 
     public function postPersist(LifecycleEventArgs $args)

--- a/src/AppBundle/Resources/config/routing.yml
+++ b/src/AppBundle/Resources/config/routing.yml
@@ -704,6 +704,22 @@ api_public_decklists_by_date:
     requirements:
         date: "\\d\\d\\d\\d-\\d\\d-\\d\\d"
 
+api_public_decklist_comments_by_uuid:
+    path: /api/2.0/public/decklist/{decklist_uuid}/comments
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:PublicApi20:commentsByDecklistUuid
+    requirements:
+        decklist_uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+
+api_public_decklist_comments_by_id:
+    path: /api/2.0/public/decklist/{decklist_id}/comments
+    methods: [GET]
+    defaults:
+        _controller: AppBundle:PublicApi20:commentsByDecklist
+    requirements:
+        decklist_id: "\\d+"
+
 api_public_deck:
     path: /api/2.0/public/deck/{deck_id}
     methods: [GET]


### PR DESCRIPTION
Hoping to use these endpoints to start populating the v3 API

Small local example:
<img width="1370" height="1017" alt="Screenshot 2026-07-15 at 12 37 50 PM" src="https://github.com/user-attachments/assets/c18681ee-ea7f-4268-a91d-659657dc3ada" />


Decklist response with social values:
<img width="1392" height="880" alt="Screenshot 2026-07-15 at 12 38 12 PM" src="https://github.com/user-attachments/assets/94215bd4-b23f-4eba-ad2b-ae187beec6a9" />


Comments by UUID:
<img width="1392" height="880" alt="Screenshot 2026-07-15 at 12 38 07 PM" src="https://github.com/user-attachments/assets/5a28ffcb-3921-421b-8748-8bcfffcfc005" />


Comments by ID:
<img width="1392" height="880" alt="Screenshot 2026-07-15 at 12 37 54 PM" src="https://github.com/user-attachments/assets/c80e9bc8-5239-4012-b275-d98374bf9800" />
